### PR TITLE
feat: Linux-stability fork — packet filters, ARP cache, crash recovery, headless/datacenter modes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install build deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-mingw-w64 imagemagick file
+          sudo apt-get install -y gcc-mingw-w64 libgtk-4-dev imagemagick file
 
       - name: Build binaries
         run: make
@@ -31,8 +31,10 @@ jobs:
             build/adapter_hook.dll
             build/rvpn_launcher.exe
             build/netsh.exe
+            build/netsh64.exe
             build/drvinst.exe
             build/tap_bridge
+            build/rvpn_filter_ui
 
       - name: Upload AppImage
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,43 @@
+# Build artifacts
 build/
-wineprefix/
+packaging/dist/
+*.o
+*.a
+*.so
+
+# Compiled Windows binaries (in root, not src/)
 *.sys
 *.dll
 *.exe
 !src/*.c
+
+# Native binaries
 tap_bridge
+rvpn_filter_ui
+
+# Wine prefix
+wineprefix/
+
+# Logs
 *.log
-*.o
+/tmp/radmin_*
+
+# Editor files
 .*.kate-swp
-packaging/dist/
+.*.swp
+*~
+.vscode/
+.idea/
+*.sublime-*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.temp
+/tmp/rvpn_*
+
+# Memory dumps
+wine_memory_monitor.txt

--- a/Makefile
+++ b/Makefile
@@ -4,20 +4,53 @@ MINGW64  = x86_64-w64-mingw32-gcc
 CFLAGS   = -Wall -O2
 BUILD    = build
 
-all: check-deps $(BUILD)/tap_bridge $(BUILD)/rvpnnetmp.sys $(BUILD)/adapter_hook.dll $(BUILD)/rvpn_launcher.exe $(BUILD)/netsh.exe $(BUILD)/drvinst.exe
+STRIP    = strip
+STRIP32  = i686-w64-mingw32-strip
+STRIP64  = x86_64-w64-mingw32-strip
+STRIP_FLAGS = -s -S --strip-debug --strip-unneeded
+
+# DDK header path differs across distros:
+#   Debian/Ubuntu:  /usr/x86_64-w64-mingw32/include/ddk
+#   Fedora/RHEL:    /usr/x86_64-w64-mingw32/sys-root/mingw/include/ddk
+DDK_INC := $(firstword $(wildcard \
+    /usr/x86_64-w64-mingw32/include/ddk \
+    /usr/x86_64-w64-mingw32/sys-root/mingw/include/ddk \
+    /usr/x86_64-w64-mingw32/sys-root/mingw/include \
+    /usr/x86_64-w64-mingw32/include \
+))
+ifeq ($(DDK_INC),)
+DDK_INC = /usr/x86_64-w64-mingw32/include/ddk
+$(warning DDK headers not found in standard paths; rvpnnetmp.sys compile may fail)
+endif
+
+# Lib path also differs (Fedora: sys-root/mingw/lib)
+MINGW64_LIB := $(firstword $(wildcard \
+    /usr/x86_64-w64-mingw32/lib \
+    /usr/x86_64-w64-mingw32/sys-root/mingw/lib \
+))
+
+BINS = $(BUILD)/tap_bridge $(BUILD)/rvpnnetmp.sys $(BUILD)/adapter_hook.dll \
+       $(BUILD)/rvpn_launcher.exe $(BUILD)/netsh.exe $(BUILD)/netsh64.exe \
+       $(BUILD)/drvinst.exe $(BUILD)/rvpn_filter_ui
+
+all: check-deps $(BINS) post-build
 
 $(BUILD)/tap_bridge: src/tap_bridge.c | $(BUILD)
-	$(CC) $(CFLAGS) -o $@ $<
+	$(CC) $(CFLAGS) -o $@ $< -lpthread
+
+$(BUILD)/rvpn_filter_ui: src/rvpn_filter_ui.c | $(BUILD)
+	$(CC) $(CFLAGS) -o $@ $< $(shell pkg-config --cflags --libs gtk4)
 
 $(BUILD)/rvpnnetmp.sys: src/rvpnnetmp.c | $(BUILD)
 	$(MINGW64) -shared -o $@ $< \
-		-I/usr/x86_64-w64-mingw32/include/ddk \
-		-lntoskrnl -lhal -nostdlib \
+		-I$(DDK_INC) \
+		$(if $(MINGW64_LIB),-L$(MINGW64_LIB)) \
+		-lntoskrnl -lhal -nostdlib -lgcc \
 		-Wl,--subsystem,native -Wl,--entry,DriverEntry
 
 $(BUILD)/adapter_hook.dll: src/adapter_hook.c | $(BUILD)
 	$(MINGW32) -shared -o $@ $< \
-		-liphlpapi -lws2_32 -Wl,--enable-stdcall-fixup
+		-liphlpapi -lws2_32 -lole32 -Wl,--enable-stdcall-fixup
 
 $(BUILD)/rvpn_launcher.exe: src/rvpn_launcher.c | $(BUILD)
 	$(MINGW32) $(CFLAGS) -o $@ $<
@@ -25,17 +58,91 @@ $(BUILD)/rvpn_launcher.exe: src/rvpn_launcher.c | $(BUILD)
 $(BUILD)/netsh.exe: src/netsh_wrapper.c | $(BUILD)
 	$(MINGW32) $(CFLAGS) -o $@ $< -municode
 
+$(BUILD)/netsh64.exe: src/netsh_wrapper.c | $(BUILD)
+	$(MINGW64) $(CFLAGS) -o $@ $< -municode
+
 $(BUILD)/drvinst.exe: src/drvinst.c | $(BUILD)
 	$(MINGW32) $(CFLAGS) -o $@ $<
+
+post-build: $(BINS)
+	@echo "[*] Stripping and compressing binaries..."
+	$(STRIP) $(STRIP_FLAGS) $(BUILD)/tap_bridge
+	$(STRIP) $(STRIP_FLAGS) $(BUILD)/rvpn_filter_ui
+	$(STRIP64) $(STRIP_FLAGS) $(BUILD)/rvpnnetmp.sys
+	$(STRIP32) $(STRIP_FLAGS) $(BUILD)/adapter_hook.dll
+	$(STRIP32) $(STRIP_FLAGS) $(BUILD)/rvpn_launcher.exe
+	$(STRIP32) $(STRIP_FLAGS) $(BUILD)/netsh.exe
+	$(STRIP64) $(STRIP_FLAGS) $(BUILD)/netsh64.exe
+	$(STRIP32) $(STRIP_FLAGS) $(BUILD)/drvinst.exe
+	# UPX nos PEs (ótimo em EXE/DLL, menos eficaz em .sys)
+	upx --best $(BUILD)/rvpn_launcher.exe $(BUILD)/netsh.exe $(BUILD)/netsh64.exe $(BUILD)/adapter_hook.dll $(BUILD)/drvinst.exe || true
+	upx --best $(BUILD)/tap_bridge || true
 
 $(BUILD):
 	mkdir -p $(BUILD)
 
+install-deps:
+	@echo "[*] Installing dependencies (requires sudo)..."
+	@if command -v apt-get >/dev/null 2>&1; then \
+		sudo apt-get update -qq && \
+		sudo apt-get install -y --no-install-recommends \
+			gcc make mingw-w64 libgtk-4-dev upx-ucl curl; \
+	elif command -v dnf >/dev/null 2>&1; then \
+		sudo dnf install -y \
+			gcc make mingw32-gcc mingw64-gcc gtk4-devel upx curl; \
+	elif command -v pacman >/dev/null 2>&1; then \
+		sudo pacman -S --noconfirm \
+			gcc make mingw-w64-gcc gtk4 upx curl; \
+	elif command -v zypper >/dev/null 2>&1; then \
+		sudo zypper install -y \
+			gcc make mingw32-cross-gcc mingw64-cross-gcc gtk4-devel upx curl; \
+	else \
+		echo "[-] Unsupported package manager. Install manually:"; \
+		echo "    gcc make mingw-w64 (i686+x86_64) gtk4-devel upx curl"; \
+		exit 1; \
+	fi
+	@echo "[+] Dependencies installed"
+
+install-datacenter-deps:
+	@echo "[*] Installing datacenter dependencies (requires sudo)..."
+	@if command -v apt-get >/dev/null 2>&1; then \
+		sudo apt-get update -qq && \
+		sudo apt-get install -y --no-install-recommends \
+			xvfb x11vnc novnc websockify; \
+	elif command -v dnf >/dev/null 2>&1; then \
+		sudo dnf install -y \
+			xorg-x11-server-Xvfb x11vnc novnc python3-websockify; \
+	elif command -v pacman >/dev/null 2>&1; then \
+		sudo pacman -S --noconfirm \
+			xorg-server-xvfb x11vnc python-websockify; \
+		echo "[!] novnc: install from AUR (yay -S novnc) or manually"; \
+	elif command -v zypper >/dev/null 2>&1; then \
+		sudo zypper install -y \
+			xorg-x11-server-extra x11vnc python3-websockify; \
+		echo "[!] novnc: install from https://novnc.com or your distro's repo"; \
+	else \
+		echo "[-] Unsupported package manager. Install manually:"; \
+		echo "    Xvfb x11vnc novnc websockify"; \
+		exit 1; \
+	fi
+	@echo "[+] Datacenter dependencies installed"
+
 check-deps:
-	@command -v $(MINGW32) >/dev/null || { echo "Missing: $(MINGW32) (install mingw-w64)"; exit 1; }
-	@command -v $(MINGW64) >/dev/null || { echo "Missing: $(MINGW64) (install mingw-w64)"; exit 1; }
+	@command -v $(MINGW32) >/dev/null || { echo "Missing: $(MINGW32) (run 'make install-deps')"; exit 1; }
+	@command -v $(MINGW64) >/dev/null || { echo "Missing: $(MINGW64) (run 'make install-deps')"; exit 1; }
+	@pkg-config --exists gtk4 || { echo "Missing: gtk4 (run 'make install-deps')"; exit 1; }
+
+appimage: check-build-artifacts
+	chmod +x packaging/build-appimage.sh
+	./packaging/build-appimage.sh
+
+check-build-artifacts:
+	@for f in tap_bridge rvpnnetmp.sys adapter_hook.dll rvpn_launcher.exe netsh.exe netsh64.exe drvinst.exe; do \
+		[ -f "$(BUILD)/$$f" ] || { echo "Missing: $(BUILD)/$$f (run 'make' first)"; exit 1; }; \
+	done
+	@if [ ! -f "$(BUILD)/rvpn_filter_ui" ]; then echo "[!] rvpn_filter_ui not found — will be skipped"; fi
 
 clean:
 	rm -rf $(BUILD)
 
-.PHONY: all check-deps clean
+.PHONY: all check-deps check-build-artifacts clean install-deps install-datacenter-deps appimage post-build

--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ On subsequent runs, just:
 ./run.sh
 ```
 
+### Command-line flags
+
+| Flag | Description |
+|------|-------------|
+| `--installer <path>` | Path to the `Radmin_VPN_*.exe` installer (first run only). |
+| `--no-ui` | Run the service without launching the Radmin GUI. |
+| `--no-broadcast-routes` | Don't add the broadcast/multicast → TAP routes. |
+| `--filter-ui` | Launch the optional GTK4 packet-filter UI (off by default). |
+| `--fix-chat` | Patch Qt's `qwindows.dll` to fix the chat-window crash under Wine (off by default). |
+
+Both `--filter-ui` and `--fix-chat` are opt-in. The filter UI needs the `rvpn_filter_ui`
+binary (built by `make`); the chat fix needs `patch_qwindows_font.py` and a Python 3 interpreter.
+
 ## Building from source
 
 Requires `mingw-w64` cross-compilers. Pre-built binaries are available from [Releases](https://github.com/baptisterajaut/radmin-vpn-linux/releases) (built by CI on each tagged version) if you don't want to install mingw.

--- a/health_check.sh
+++ b/health_check.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# health_check.sh - Diagnostic script for Radmin VPN Linux
+# This script checks system prerequisites and common issues
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+check_pass() {
+    echo -e "${GREEN}[✓]${NC} $1"
+}
+
+check_fail() {
+    echo -e "${RED}[✗]${NC} $1"
+}
+
+check_warn() {
+    echo -e "${YELLOW}[!]${NC} $1"
+}
+
+echo "=== Radmin VPN Linux Health Check ==="
+echo
+
+# Check Wine
+echo "Checking Wine installation..."
+if command -v wine >/dev/null 2>&1; then
+    WINE_VERSION=$(wine --version)
+    check_pass "Wine installed: $WINE_VERSION"
+    # Extract version number for comparison
+    WINE_MAJOR=$(echo "$WINE_VERSION" | grep -oP 'wine-\K\d+' || echo "0")
+    if [ "$WINE_MAJOR" -ge 11 ]; then
+        check_pass "Wine version >= 11.0"
+    else
+        check_fail "Wine version < 11.0 (required: >= 11.0)"
+    fi
+else
+    check_fail "Wine not found"
+fi
+echo
+
+# Check wineserver
+echo "Checking wineserver..."
+if command -v wineserver >/dev/null 2>&1; then
+    check_pass "wineserver found"
+else
+    check_fail "wineserver not found"
+fi
+echo
+
+# Check mingw-w64 compilers
+echo "Checking mingw-w64 compilers..."
+if command -v i686-w64-mingw32-gcc >/dev/null 2>&1; then
+    check_pass "i686-w64-mingw32-gcc found"
+else
+    check_fail "i686-w64-mingw32-gcc not found (run 'make install-deps')"
+fi
+
+if command -v x86_64-w64-mingw32-gcc >/dev/null 2>&1; then
+    check_pass "x86_64-w64-mingw32-gcc found"
+else
+    check_fail "x86_64-w64-mingw32-gcc not found (run 'make install-deps')"
+fi
+echo
+
+# Check gcc for native builds
+echo "Checking native gcc..."
+if command -v gcc >/dev/null 2>&1; then
+    check_pass "gcc found"
+else
+    check_fail "gcc not found"
+fi
+echo
+
+# Check python3
+echo "Checking python3..."
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON_VERSION=$(python3 --version)
+    check_pass "python3 found: $PYTHON_VERSION"
+else
+    check_fail "python3 not found"
+fi
+echo
+
+# Check TUN/TAP support
+echo "Checking TUN/TAP kernel support..."
+if modprobe tun 2>/dev/null; then
+    check_pass "TUN/TAP module available"
+else
+    check_fail "TUN/TAP module not available"
+fi
+
+if [ -c /dev/net/tun ]; then
+    check_pass "/dev/net/tun device exists"
+else
+    check_fail "/dev/net/tun device not found"
+fi
+echo
+
+# Check sudo access
+echo "Checking sudo access..."
+if sudo -n true 2>/dev/null; then
+    check_pass "Sudo access available (no password required)"
+elif sudo -v 2>/dev/null; then
+    check_pass "Sudo access available (password required)"
+else
+    check_fail "Sudo access not available (required for TAP device)"
+fi
+echo
+
+# Check build artifacts
+echo "Checking build artifacts..."
+BUILD_DIR="./build"
+if [ -d "$BUILD_DIR" ]; then
+    check_pass "Build directory exists"
+    
+    [ -f "$BUILD_DIR/tap_bridge" ] && check_pass "tap_bridge built" || check_fail "tap_bridge missing"
+    [ -f "$BUILD_DIR/rvpnnetmp.sys" ] && check_pass "rvpnnetmp.sys built" || check_fail "rvpnnetmp.sys missing"
+    [ -f "$BUILD_DIR/adapter_hook.dll" ] && check_pass "adapter_hook.dll built" || check_fail "adapter_hook.dll missing"
+    [ -f "$BUILD_DIR/rvpn_launcher.exe" ] && check_pass "rvpn_launcher.exe built" || check_fail "rvpn_launcher.exe missing"
+    [ -f "$BUILD_DIR/netsh.exe" ] && check_pass "netsh.exe built" || check_fail "netsh.exe missing"
+    [ -f "$BUILD_DIR/netsh64.exe" ] && check_pass "netsh64.exe built" || check_fail "netsh64.exe missing"
+else
+    check_warn "Build directory not found (run 'make' to build)"
+fi
+echo
+
+# Check wineprefix
+echo "Checking wineprefix..."
+WINEPREFIX="./wineprefix"
+if [ -d "$WINEPREFIX" ]; then
+    check_pass "wineprefix exists"
+    
+    if [ -f "$WINEPREFIX/drive_c/Program Files (x86)/Radmin VPN/RvControlSvc.exe" ]; then
+        check_pass "Radmin VPN installed"
+    else
+        check_warn "Radmin VPN not installed in wineprefix"
+    fi
+else
+    check_warn "wineprefix not found (will be created on first run)"
+fi
+echo
+
+# Check for running processes
+echo "Checking for running Radmin VPN processes..."
+if pgrep -f "RvControlSvc.exe" >/dev/null 2>&1; then
+    check_warn "RvControlSvc.exe is running"
+else
+    check_pass "No RvControlSvc.exe process found"
+fi
+
+if pgrep -f "tap_bridge" >/dev/null 2>&1; then
+    check_warn "tap_bridge is running"
+else
+    check_pass "No tap_bridge process found"
+fi
+echo
+
+# Check TAP device
+echo "Checking TAP device..."
+if ip link show radminvpn0 >/dev/null 2>&1; then
+    check_pass "radminvpn0 TAP device exists"
+    ip link show radminvpn0
+else
+    check_pass "No radminvpn0 TAP device found (normal when not running)"
+fi
+echo
+
+# Check for installer
+echo "Checking for Radmin VPN installer..."
+INSTALLER=$(find . -maxdepth 2 -name "Radmin_VPN_*.exe" -print -quit 2>/dev/null || true)
+if [ -n "$INSTALLER" ]; then
+    check_pass "Installer found: $INSTALLER"
+else
+    check_warn "No installer found in current directory"
+fi
+echo
+
+echo "=== Health Check Complete ==="

--- a/packaging/AppRun
+++ b/packaging/AppRun
@@ -32,9 +32,13 @@ export WINELOADER="$APPDIR/wine/bin/wine"
 export WINESERVER="$APPDIR/wine/bin/wineserver"
 
 # ---- Env for run.sh ----
+# run.sh reads WINEPREFIX and BUILD_DIR from environment when set.
+# We override them here so everything is self-contained within the AppImage
+# and the persistent data dir.
 export WINEPREFIX="$DATA_DIR/wineprefix"
 export BUILD_DIR="$APPDIR/usr/lib/radmin-vpn"
 export RADMIN_DATA_DIR="$DATA_DIR"
+export RADMIN_INSTALLER_URL="https://download.radmin-vpn.com/download/files/Radmin_VPN_2.0.4899.9.exe"
 
 # ---- Askpass: native binary, else synthesize via zenity/kdialog ----
 if [ -z "${SUDO_ASKPASS:-}" ] && [ -n "${DISPLAY:-${WAYLAND_DISPLAY:-}}" ]; then

--- a/packaging/build-appimage.sh
+++ b/packaging/build-appimage.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Builds RadminVPN-Linux-x86_64.AppImage
 #
-# Inputs:  build/ populated with {tap_bridge, rvpnnetmp.sys, adapter_hook.dll,
-#                                  rvpn_launcher.exe, netsh.exe, drvinst.exe}
+# Inputs:  build/ populated with {tap_bridge, rvpn_filter_ui,
+#                                  rvpnnetmp.sys, adapter_hook.dll,
+#                                  rvpn_launcher.exe, netsh.exe, netsh64.exe}
 # Output:  packaging/dist/RadminVPN-Linux-x86_64.AppImage
 #
 # Deps:    curl, ImageMagick (convert), appimagetool (auto-downloaded)
@@ -20,7 +21,7 @@ OUT="$DIST/RadminVPN-Linux-x86_64.AppImage"
 echo "[*] radmin-vpn-linux AppImage build"
 
 # ---- Preflight ----
-for f in tap_bridge rvpnnetmp.sys adapter_hook.dll rvpn_launcher.exe netsh.exe drvinst.exe; do
+for f in tap_bridge rvpnnetmp.sys adapter_hook.dll rvpn_launcher.exe netsh.exe netsh64.exe drvinst.exe; do
     [ -f "$BUILD/$f" ] || { echo "[-] Missing $BUILD/$f (run 'make' first)"; exit 1; }
 done
 command -v curl    >/dev/null || { echo "[-] curl required"; exit 1; }
@@ -89,8 +90,22 @@ cp "$BUILD/rvpnnetmp.sys"      "$APPDIR/usr/lib/radmin-vpn/"
 cp "$BUILD/adapter_hook.dll"   "$APPDIR/usr/lib/radmin-vpn/"
 cp "$BUILD/rvpn_launcher.exe"  "$APPDIR/usr/lib/radmin-vpn/"
 cp "$BUILD/netsh.exe"          "$APPDIR/usr/lib/radmin-vpn/"
+cp "$BUILD/netsh64.exe"        "$APPDIR/usr/lib/radmin-vpn/"
 cp "$BUILD/drvinst.exe"        "$APPDIR/usr/lib/radmin-vpn/"
 chmod +x "$APPDIR/usr/lib/radmin-vpn/tap_bridge"
+
+# rvpn_filter_ui is optional (GTK4 Linux binary) — bundle if present
+if [ -f "$BUILD/rvpn_filter_ui" ]; then
+    cp "$BUILD/rvpn_filter_ui" "$APPDIR/usr/lib/radmin-vpn/"
+    chmod +x "$APPDIR/usr/lib/radmin-vpn/rvpn_filter_ui"
+    echo "[*] Bundled rvpn_filter_ui"
+else
+    echo "[!] rvpn_filter_ui not found in build/ — skipping (--no-ui will be implied)"
+fi
+
+# Radmin VPN Windows installer is intentionally NOT bundled — it is downloaded
+# at runtime (RADMIN_INSTALLER_URL). Never ship the proprietary installer inside
+# the AppImage.
 
 # run.sh (adapted, lives in the AppImage; sourced via AppRun)
 cp "$ROOT/run.sh" "$APPDIR/usr/bin/run.sh"

--- a/patch_qwindows_font.py
+++ b/patch_qwindows_font.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Patch Qt's qwindows.dll platform plugin to stop crashing on malformed font
+# name-table offsets under Wine.
+#
+# Root cause (see run.sh comment): QWindowsFontDatabase reads a self-relative
+# UTF-16 name offset from a GDI OUTLINETEXTMETRIC/font-data buffer and does
+#     QString::fromUtf16(buffer + offset, -1)
+# Under Wine, GetOutlineTextMetricsW/GetFontData fill that offset with garbage
+# for some host fonts (observed 0xC0000000 and 0x40dde2c4). buffer+offset then
+# points to unmapped memory and the -1 (auto-length) NUL-scan in fromUtf16
+# faults (0xc0000005). On real Windows the page happens to be committed so it
+# only yields garbage, never a crash.
+#
+# Fix: at the crashing call site (qwindows+0x5f50d) bound-check the offset.
+# A valid otmp name offset is tiny (< 64 KiB). If it is out of range, call
+# fromUtf16(buffer, 0) instead -> returns an empty QString with no dereference.
+# Normal fonts (small valid offset) are completely unaffected.
+#
+# Idempotent: detects an already-patched file and does nothing. Keeps a .orig
+# backup next to the dll the first time it patches.
+import struct, sys, os
+
+SITE_RVA  = 0x5f50d   # mov eax,[ebx+0xd4]; add eax,ebx; push -1; push eax
+BACK_RVA  = 0x5f518   # lea eax,[esp+0x1c]; push eax; call fromUtf16
+CAVE_RVA  = 0x11e89   # 39-byte 0xCC pad run
+ORIG_SITE = bytes.fromhex("8b83d4000000" "03c3" "6aff" "50")  # 11 bytes
+
+def rva2off(secs, rva):
+    for va, vs, ptr, rs in secs:
+        if va <= rva < va + max(vs, rs):
+            return ptr + (rva - va)
+    raise ValueError(f"rva {rva:#x} not in any section")
+
+def main(path):
+    d = bytearray(open(path, "rb").read())
+    pe = struct.unpack_from("<I", d, 0x3c)[0]
+    if d[pe:pe+2] != b"PE":
+        sys.exit("not a PE")
+    nsec = struct.unpack_from("<H", d, pe+6)[0]
+    opt  = pe + 24
+    imgbase = struct.unpack_from("<I", d, opt+28)[0]
+    sh = opt + struct.unpack_from("<H", d, pe+20)[0]
+    secs = []
+    for i in range(nsec):
+        o = sh + i*40
+        vs, va, rs, ptr = struct.unpack_from("<IIII", d, o+8)
+        secs.append((va, vs, ptr, rs))
+
+    site = rva2off(secs, SITE_RVA)
+    cave = rva2off(secs, CAVE_RVA)
+
+    if d[site] == 0xE9:
+        print("qwindows.dll already patched; nothing to do.")
+        return 0
+    if bytes(d[site:site+11]) != ORIG_SITE:
+        sys.exit(f"unexpected bytes at site: {bytes(d[site:site+11]).hex()} "
+                 f"(expected {ORIG_SITE.hex()}) -- wrong/newer qwindows.dll, aborting")
+
+    site_va = imgbase + SITE_RVA
+    back_va = imgbase + BACK_RVA
+    cave_va = imgbase + CAVE_RVA
+
+    # ---- build cave ----
+    cave_bytes = bytearray()
+    cave_bytes += bytes.fromhex("8b83d4000000")          # mov eax,[ebx+0xd4]
+    cave_bytes += bytes.fromhex("3d00000100")            # cmp eax,0x10000
+    jae_at = len(cave_bytes)
+    cave_bytes += bytes.fromhex("7300")                  # jae rel8 -> bad (fix below)
+    cave_bytes += bytes.fromhex("03c3")                  # add eax,ebx
+    cave_bytes += bytes.fromhex("68ffffffff")            # push 0xffffffff (size=-1)
+    cave_bytes += bytes.fromhex("50")                    # push eax (ptr)
+    # jmp back (good path)
+    here = cave_va + len(cave_bytes)
+    cave_bytes += b"\xe9" + struct.pack("<i", back_va - (here + 5))
+    # bad path (jae lands here): size=0, ptr=ebx (valid, never read)
+    bad_off = len(cave_bytes)
+    cave_bytes += bytes.fromhex("6a00")                  # push 0 (size=0)
+    cave_bytes += bytes.fromhex("53")                    # push ebx (ptr)
+    here = cave_va + len(cave_bytes)
+    cave_bytes += b"\xe9" + struct.pack("<i", back_va - (here + 5))
+
+    # fix jae rel8 (displacement from end of the 2-byte jae to bad_off)
+    rel = bad_off - (jae_at + 2)
+    assert 0 <= rel <= 0x7f, f"jae rel out of range: {rel}"
+    cave_bytes[jae_at+1] = rel
+    assert len(cave_bytes) <= 39, f"cave too big: {len(cave_bytes)}"
+
+    # ---- write cave ----
+    if any(b != 0xCC for b in d[cave:cave+len(cave_bytes)]):
+        sys.exit("cave region not free (expected 0xCC padding)")
+    d[cave:cave+len(cave_bytes)] = cave_bytes
+
+    # ---- write site: jmp cave (5) + nop padding to 11 ----
+    patch = b"\xe9" + struct.pack("<i", cave_va - (site_va + 5))
+    patch += b"\x90" * (11 - len(patch))
+    d[site:site+11] = patch
+
+    if not os.path.exists(path + ".orig"):
+        os.rename(path, path + ".orig")
+        open(path, "wb").write(d)   # recreate at original name
+    else:
+        open(path, "wb").write(d)
+    print(f"patched {path}\n  site {SITE_RVA:#x} -> jmp cave {CAVE_RVA:#x}, "
+          f"cave {len(cave_bytes)} bytes, back {BACK_RVA:#x}")
+    return 0
+
+if __name__ == "__main__":
+    p = sys.argv[1] if len(sys.argv) > 1 else "qwindows.dll"
+    sys.exit(main(p))

--- a/run.sh
+++ b/run.sh
@@ -1,20 +1,56 @@
 #!/bin/bash
 # run.sh - Radmin VPN on Linux
-# Usage: ./run.sh [--installer /path/to/Radmin_VPN_*.exe]
+# Usage: ./run.sh [--installer /path/to/Radmin_VPN_*.exe] [--no-ui]
+#                 [--no-broadcast-routes] [--filter-ui] [--fix-chat]
+#   --filter-ui  launch the optional GTK4 packet-filter UI (off by default)
+#   --fix-chat   patch Qt qwindows.dll to fix the chat crash (off by default)
 set -euo pipefail
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
-export WINEDEBUG="-all"
-# Disable wine-mono + wine-gecko auto-install dialogs — Radmin VPN needs neither.
-# netsh.exe override is set LATER (just before service start) — setting it here breaks
-# the Inno Setup firewall CA on fresh prefixes (our netsh wrapper isn't copied yet,
-# "n" blocks the builtin fallback, CreateProcess fails with c0000135 → install rolls back).
-export WINEDLLOVERRIDES="mscoree=;mshtml="
-# Suppress core dumps from expected transient crashes (Radmin's NDIS driver loading under wine).
-# Keeps systemd-coredump / DrKonqi / apport quiet.
-ulimit -c 0 2>/dev/null || true
+
+# ── Portability helpers ───────────────────────────────────────────────────────
+
+_distro() {
+    if command -v dnf     >/dev/null 2>&1; then printf 'fedora'
+    elif command -v apt-get >/dev/null 2>&1; then printf 'debian'
+    elif command -v pacman  >/dev/null 2>&1; then printf 'arch'
+    elif command -v zypper  >/dev/null 2>&1; then printf 'suse'
+    else printf 'unknown'; fi
+}
+
+_wine_install_hint() {
+    case "$(_distro)" in
+        fedora)  echo "  sudo dnf install wine winetricks  # ou adicione o repo WineHQ para versão mais recente" ;;
+        debian)  echo "  sudo apt install wine winetricks" ;;
+        arch)    echo "  sudo pacman -S wine winetricks" ;;
+        suse)    echo "  sudo zypper install wine winetricks" ;;
+        *)       echo "  Instale wine em: https://www.winehq.org/" ;;
+    esac
+}
+
+wine_version_str() { wine --version 2>/dev/null | head -n1; }
+wine_major() { wine_version_str | sed -n 's/^wine-\([0-9]\+\).*/\1/p'; }
+
+_http_get() {
+    local dest="$1" url="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fL -o "$dest" "$url" 2>/dev/null
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q -O "$dest" "$url" 2>/dev/null
+    else
+        return 1
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# When launched from the AppImage, AppRun already exports WINEPREFIX and BUILD_DIR.
+# Fall back to the traditional $DIR-relative paths when running directly.
 export WINEPREFIX="${WINEPREFIX:-$DIR/wineprefix}"
-RADMIN_DIR="$WINEPREFIX/drive_c/Program Files (x86)/Radmin VPN"
+# Disable Wine debug output to reduce memory consumption
+export WINEDEBUG=-all
+# Reduce glibc memory arenas to prevent fragmentation
+export MALLOC_ARENA_MAX=2
+RADMIN="$WINEPREFIX/drive_c/Program Files (x86)/Radmin VPN"
 BUILD_DIR="${BUILD_DIR:-$DIR/build}"
 TAP_DEV="radminvpn0"
 CMD_FILE="/tmp/radmin_netsh_cmd"
@@ -22,334 +58,218 @@ LOG="$WINEPREFIX/drive_c/ProgramData/Famatech/Radmin VPN/service.log"
 MAC_FILE="$WINEPREFIX/radmin_mac"
 RELAY_PID=""
 BRIDGE_PID=""
-
-# GUI fallback helpers: zenity → kdialog → xmessage → stdout/stdin
-gui_info() {
-    command -v zenity   >/dev/null 2>&1 && { zenity --info --title="$1" --no-wrap --text="$2" 2>/dev/null && return; }
-    command -v kdialog  >/dev/null 2>&1 && { kdialog --title "$1" --msgbox "$2" 2>/dev/null && return; }
-    command -v xmessage >/dev/null 2>&1 && { xmessage -center -buttons OK "$1: $2" 2>/dev/null && return; }
-    echo "[*] $2"
-}
-gui_pick_installer() {
-    command -v zenity  >/dev/null 2>&1 && { zenity --file-selection --title="Select Radmin VPN installer" --file-filter="Radmin VPN installer | Radmin_VPN_*.exe" 2>/dev/null && return; }
-    command -v kdialog >/dev/null 2>&1 && { kdialog --title "Select Radmin VPN installer" --getopenfilename "$HOME" "Radmin_VPN_*.exe" 2>/dev/null && return; }
-    echo "[?] Enter path to Radmin VPN installer (Radmin_VPN_*.exe):" >&2
-    read -r _p && printf '%s\n' "$_p"
-}
-
-dump_log() {
-    local name="$1" path="$2" transform="${3:-}"
-    echo "--- $name ($path) ---"
-    if [ ! -e "$path" ]; then
-        echo "  (file not found)"
-    elif [ ! -s "$path" ]; then
-        echo "  (empty)"
-    elif [ "$transform" = "utf16" ]; then
-        iconv -f UTF-16LE -t UTF-8 "$path" 2>/dev/null | tail -n 40 | sed 's/^/  /'
-    else
-        tail -n 40 "$path" | sed 's/^/  /'
-    fi
-    echo ""
-}
-
-# Wine version utils. AppImage (bundled) sets $APPIMAGE; system Wine does not.
-wine_version_str() { wine --version 2>/dev/null | head -n1; }
-wine_major() { wine_version_str | sed -n 's/^wine-\([0-9]\+\).*/\1/p'; }
-
-DIAG_FAILS=0
-diag_ok()   { echo "  [ok]   $1"; }
-diag_miss() { echo "  [MISS] $1"; DIAG_FAILS=$((DIAG_FAILS+1)); }
-diag_bad()  { echo "  [BAD]  $1"; DIAG_FAILS=$((DIAG_FAILS+1)); }
-
-dump_diagnostics() {
-    DIAG_FAILS=0
-    echo ""
-    echo "===================== DIAGNOSTICS ====================="
-    echo "[-] $1"
-    echo ""
-
-    echo "--- Environment ---"
-    local wv wmaj src
-    wv=$(wine_version_str || echo '?')
-    wmaj=$(wine_major || echo 0)
-    if [ -n "${APPIMAGE:-}" ]; then
-        src="bundled (AppImage)"
-    else
-        src="system ($(command -v wine 2>/dev/null || echo '?'))"
-    fi
-    echo "  [info] Wine: $wv — $src"
-    if [ "${wmaj:-0}" -lt 11 ] 2>/dev/null; then
-        diag_bad "Wine $wv is older than 11.0 — known to break the driver (overlapped I/O changes)"
-    fi
-    echo "  [info] WINEPREFIX: $WINEPREFIX"
-    echo "  [info] Kernel: $(uname -srm)"
-    echo ""
-
-    echo "--- Processes ---"
-    for name in RvControlSvc.exe rvpn_launcher.exe services.exe wineserver tap_bridge; do
-        local pids
-        pids=$(pgrep -af "$name" 2>/dev/null || true)
-        if [ -n "$pids" ]; then
-            echo "  [alive] $name"
-            printf '%s\n' "$pids" | sed 's/^/          /'
-        else
-            echo "  [dead]  $name"
-        fi
-    done
-    echo ""
-
-    echo "--- Sanity checks ---"
-    [ -f "$WINEPREFIX/drive_c/windows/system32/drivers/rvpnnetmp.sys" ] \
-        && diag_ok "driver rvpnnetmp.sys installed" \
-        || diag_miss "driver rvpnnetmp.sys missing"
-    [ -f "$RADMIN_DIR/RvControlSvc.exe" ] \
-        && diag_ok "RvControlSvc.exe present" \
-        || diag_miss "RvControlSvc.exe missing"
-    [ -f "$RADMIN_DIR/adapter_hook.dll" ] \
-        && diag_ok "adapter_hook.dll present" \
-        || diag_miss "adapter_hook.dll missing"
-    [ -f "$RADMIN_DIR/rvpn_launcher.exe" ] \
-        && diag_ok "rvpn_launcher.exe present" \
-        || diag_miss "rvpn_launcher.exe missing"
-    [ -f "$WINEPREFIX/drive_c/windows/syswow64/netsh.exe" ] \
-        && diag_ok "netsh.exe wrapper installed" \
-        || diag_miss "netsh.exe wrapper missing"
-    if [ -p /tmp/rvpn_b2d ] && [ -p /tmp/rvpn_d2b ]; then
-        diag_ok "FIFOs /tmp/rvpn_{b2d,d2b}"
-    else
-        diag_miss "FIFOs /tmp/rvpn_{b2d,d2b}"
-    fi
-    if [ -f /tmp/rvpn_mac ] && [ "$(stat -c%s /tmp/rvpn_mac 2>/dev/null)" = "6" ]; then
-        diag_ok "/tmp/rvpn_mac (6 bytes)"
-    else
-        diag_bad "/tmp/rvpn_mac missing or wrong size"
-    fi
-    if ip link show "$TAP_DEV" >/dev/null 2>&1; then
-        diag_ok "TAP $TAP_DEV up ($(ip -br link show "$TAP_DEV" | awk '{print $2,$3}'))"
-    else
-        diag_miss "TAP $TAP_DEV not found"
-    fi
-    local rvpn_start
-    rvpn_start=$(wine reg query "HKLM\\SYSTEM\\CurrentControlSet\\Services\\rvpnnetmp" /v Start 2>/dev/null \
-        | grep -oE '0x[0-9a-f]+' | head -n1)
-    [ -n "$rvpn_start" ] \
-        && diag_ok "registry rvpnnetmp (Start=$rvpn_start)" \
-        || diag_miss "registry rvpnnetmp not found"
-    echo ""
-
-    dump_log "launcher stdout/stderr" /tmp/radmin_service.log
-    dump_log "driver log"             "$WINEPREFIX/drive_c/radmin_driver.log"
-    dump_log "adapter_hook log"       "$WINEPREFIX/drive_c/radmin_hook_debug.log"
-    dump_log "service log (Famatech)" "$LOG" utf16
-    dump_log "tap_bridge log"         /tmp/radmin_bridge.log
-
-    echo "--- Summary ---"
-    if [ "$DIAG_FAILS" -eq 0 ]; then
-        echo "  All sanity checks passed."
-    else
-        echo "  $DIAG_FAILS check(s) failed — see [MISS]/[BAD] above."
-    fi
-    echo "======================================================="
-    echo ""
-    echo "Please attach the block above when reporting a bug:"
-    echo "  https://github.com/baptisterajaut/radmin-vpn-linux/issues"
-    echo ""
-}
-
-# Retry the service once with Wine err-channel logging enabled. Called only when
-# dump_diagnostics found nothing wrong — gives us a hope of catching the crash
-# cause when the launcher log is empty (service dies before writing anything).
-retry_verbose() {
-    echo "[*] All sanity checks passed — retrying with WINEDEBUG=err+all to capture the crash..."
-    echo ""
-    wineserver -k 2>/dev/null || true
-    sleep 1
-    ( cd "$RADMIN_DIR" && \
-        WINEDEBUG="err+all,fixme-all" timeout 15 wine rvpn_launcher.exe /run \
-        > /tmp/radmin_service_verbose.log 2>&1 ) || true
-    wineserver -k 2>/dev/null || true
-    sleep 1
-    dump_log "verbose launcher output (WINEDEBUG=err+all)" /tmp/radmin_service_verbose.log
-}
+FILTER_UI_PID=""
+MONITOR_PID=""
+NO_UI=0
+FILTER_UI=0
+FIX_CHAT=0
 
 # Parse args
 INSTALLER=""
-NO_BCAST_ROUTES=0
 for arg in "$@"; do
     case "$arg" in
         --installer) shift; INSTALLER="$1"; shift ;;
         --installer=*) INSTALLER="${arg#*=}" ;;
+        --no-ui) NO_UI=1 ;;
         --no-broadcast-routes) NO_BCAST_ROUTES=1 ;;
+        --filter-ui) FILTER_UI=1 ;;
+        --fix-chat) FIX_CHAT=1 ;;
     esac
 done
+NO_BCAST_ROUTES="${NO_BCAST_ROUTES:-0}"
 
-# Find installer if not specified (search common locations)
+# Find installer if not specified
 if [ -z "$INSTALLER" ]; then
-    for p in "$DIR" "${RADMIN_DATA_DIR:-}" "$HOME/Downloads" "$PWD"; do
-        [ -n "$p" ] && [ -d "$p" ] || continue
-        INSTALLER=$(find "$p" -maxdepth 1 -name "Radmin_VPN_*.exe" -print -quit 2>/dev/null || true)
-        [ -n "$INSTALLER" ] && break
-    done
+    # Search project dir first, then BUILD_DIR (where AppImage bundles it)
+    INSTALLER=$(find "$DIR" -maxdepth 1 -name "Radmin_VPN_*.exe" -print -quit 2>/dev/null || true)
+    if [ -z "$INSTALLER" ]; then
+        INSTALLER=$(find "$BUILD_DIR" -maxdepth 1 -name "Radmin_VPN_*.exe" -print -quit 2>/dev/null || true)
+    fi
 fi
-# No installer found + Radmin not installed → prompt user
-if [ -z "$INSTALLER" ] && [ ! -f "$RADMIN_DIR/RvControlSvc.exe" ]; then
-    gui_info "Radmin VPN — installer needed" \
-        "Radmin VPN installer not found.\n\nDownload Radmin_VPN_*.exe from https://www.radmin-vpn.com/\nand select it in the next window."
-    INSTALLER=$(gui_pick_installer || true)
+
+# Download installer at runtime if still not found
+INSTALLER_URL="${RADMIN_INSTALLER_URL:-https://download.radmin-vpn.com/download/files/Radmin_VPN_2.0.4899.9.exe}"
+if [ -z "$INSTALLER" ] || [ ! -f "$INSTALLER" ]; then
+    DOWNLOAD_DIR="${RADMIN_DATA_DIR:-$HOME/.local/share/radmin-vpn-linux}"
+    mkdir -p "$DOWNLOAD_DIR"
+    INSTALLER="$DOWNLOAD_DIR/Radmin_VPN_2.0.4899.9.exe"
+    if [ ! -f "$INSTALLER" ]; then
+        _http_get "$INSTALLER" "$INSTALLER_URL" || { echo "Erro: download falhou (instale curl ou wget)"; exit 1; }
+    fi
 fi
 
 cleanup() {
-    echo "[*] Stopping..."
+    [ -n "$FILTER_UI_PID" ] && kill "$FILTER_UI_PID" 2>/dev/null || true
     wineserver -k 2>/dev/null || true
-    sleep 1
+    [ -n "$MONITOR_PID" ] && kill "$MONITOR_PID" 2>/dev/null || true
     [ -n "$BRIDGE_PID" ] && kill "$BRIDGE_PID" 2>/dev/null || true
     [ -n "$RELAY_PID" ] && kill "$RELAY_PID" 2>/dev/null || true
     sudo ip link delete "$TAP_DEV" 2>/dev/null || true
-    rm -f "$CMD_FILE" "${CMD_FILE}.proc" /tmp/rvpn_b2d /tmp/rvpn_d2b /tmp/rvpn_mac
-    echo "[*] Done"
+    rm -f "$CMD_FILE" "${CMD_FILE}.proc" /tmp/rvpn_b2d /tmp/rvpn_d2b /tmp/rvpn_mac /tmp/rvpn_filters.json
+    # Collect a debug bundle of everything captured this run.
+    if [ "${RVPN_DEBUG:-0}" = "1" ]; then
+        BUND="/tmp/rvpn_debug_$(date +%Y%m%d_%H%M%S)"
+        mkdir -p "$BUND" 2>/dev/null || true
+        cp /tmp/radmin_*.log "$BUND/" 2>/dev/null || true
+        cp /tmp/rvpn_filters.json "$BUND/" 2>/dev/null || true
+        iconv -f UTF-16LE -t UTF-8 "$LOG" > "$BUND/service.log.txt" 2>/dev/null || cp "$LOG" "$BUND/service.log" 2>/dev/null || true
+        cp "$WINEPREFIX/drive_c/radmin_crash.log"      "$BUND/" 2>/dev/null || true
+        cp "$WINEPREFIX/drive_c/radmin_hook_debug.log" "$BUND/" 2>/dev/null || true
+        cp "$WINEPREFIX/drive_c/radmin_driver.log" /tmp/radmin_driver.log "$BUND/" 2>/dev/null || true
+        {
+            echo "== ip addr =="; ip addr 2>&1
+            echo; echo "== ip route =="; ip route 2>&1
+            echo; echo "== ip -s link show $TAP_DEV =="; ip -s link show "$TAP_DEV" 2>&1
+        } > "$BUND/net_state.txt" 2>&1 || true
+        { dmesg 2>/dev/null || sudo dmesg 2>/dev/null; } | tail -150 > "$BUND/dmesg_tail.txt" 2>/dev/null || true
+        echo ""
+        echo "[*] Debug bundle salvo em: $BUND"
+        if [ -s "$WINEPREFIX/drive_c/radmin_crash.log" ]; then
+            echo "[!] CRASH capturado — resumo:"
+            grep -E 'CRASH|code=0x|access-violation|  #0[0-3] ' "$WINEPREFIX/drive_c/radmin_crash.log" | tail -12
+        fi
+    fi
 }
 trap cleanup EXIT
 
-echo "[*] Radmin VPN for Linux"
+echo "Radmin VPN - starting service..."
 
 # Prerequisites
-command -v wine >/dev/null || { echo "[-] Wine not found. Install wine."; exit 1; }
-command -v wineserver >/dev/null || { echo "[-] wineserver not found."; exit 1; }
-command -v iconv >/dev/null || { echo "[-] iconv not found."; exit 1; }
-# Wine version gate: we require >= 11.0 for overlapped I/O semantics. Bundled Wine
-# in the AppImage is 11.6, so this only trips on system Wine installs.
+_missing=""
+command -v wine       >/dev/null || _missing="$_missing wine"
+command -v wineserver >/dev/null || _missing="$_missing wineserver"
+command -v python3    >/dev/null || _missing="$_missing python3"
+command -v ip         >/dev/null || _missing="$_missing ip(iproute2)"
+if [ -n "$_missing" ]; then
+    echo "Erro: dependências ausentes:$_missing"
+    _wine_install_hint
+    exit 1
+fi
+if [ -z "${RADMIN_SUDO_PRIMED:-}" ]; then
+    sudo -v || { echo "Erro: permissão insuficiente (sudo necessário para dispositivo TAP)"; exit 1; }
+fi
+
+# Wine version gate: requires >= 11.0 for overlapped I/O semantics.
 WINE_VERSION_STR=$(wine_version_str || echo '?')
 WINE_MAJOR=$(wine_major || echo 0)
 if [ -n "${APPIMAGE:-}" ]; then
-    echo "[*] Using bundled Wine ($WINE_VERSION_STR)"
+    echo "[*] Wine bundled: $WINE_VERSION_STR"
 elif ! [ "${WINE_MAJOR:-0}" -ge 11 ] 2>/dev/null; then
-    echo "[-] Wine $WINE_VERSION_STR is too old — Radmin VPN requires Wine >= 11.0."
-    echo "    Upgrade wine-staging on your distro, or use the AppImage release"
-    echo "    (https://github.com/baptisterajaut/radmin-vpn-linux/releases) which"
-    echo "    bundles Wine 11.6."
+    echo "[-] Wine $WINE_VERSION_STR muito antigo — requer Wine >= 11.0."
+    echo "    Atualize wine-staging ou use o AppImage com Wine 11.x embutido."
+    _wine_install_hint
     exit 1
 fi
-# Skip sudo validation if AppRun already primed it (avoids a second password prompt).
-if [ "${RADMIN_SUDO_PRIMED:-}" != "1" ]; then
-    sudo -v || { echo "[-] Need sudo for TAP device."; exit 1; }
+
+# Warn about SELinux (Fedora/RHEL) — can silently block tap_bridge and Wine pipes
+if command -v getenforce >/dev/null 2>&1 && [ "$(getenforce 2>/dev/null)" = "Enforcing" ]; then
+    echo "Aviso: SELinux Enforcing detectado. Em caso de falha, tente:"
+    echo "  sudo setsebool -P allow_execmod on"
+    echo "  sudo chcon -t bin_t \"$BUILD_DIR/tap_bridge\""
 fi
 
 # 1. Kill any previous Wine session
+# Kill wine processes before the server so they exit cleanly rather than
+# crashing mid-cleanup (a crashing wine process can trigger DispatchCleanup
+# while Wine's internal state is already being torn down → ntdll crash).
+pkill -f "RvControlSvc|RvRvpnGui|rvpn_launcher" 2>/dev/null || true
+sleep 0.3
 wineserver -k 2>/dev/null || true
-sleep 1
+# Configure wineserver to use less memory
+wineserver -p 2>/dev/null || true
 
 # 2. Install Radmin if not present
-if [ ! -f "$RADMIN_DIR/RvControlSvc.exe" ]; then
+if [ ! -f "$RADMIN/RvControlSvc.exe" ]; then
     if [ -z "$INSTALLER" ] || [ ! -f "$INSTALLER" ]; then
-        echo "[-] Radmin VPN not installed and no installer found."
-        echo "    Download from https://www.radmin-vpn.com/ and run:"
-        echo "    ./run.sh --installer /path/to/Radmin_VPN_*.exe"
+        echo "Erro: instalador não encontrado"
         exit 1
     fi
-    echo "[*] Installing Radmin VPN..."
     mkdir -p "$WINEPREFIX"
     wineboot --init 2>/dev/null
-    echo "[+] Wine prefix created"
+    if command -v winetricks >/dev/null 2>&1; then
+        winetricks -q d3dcompiler_47 d3dx11_43 dxvk 2>/dev/null || true
+    fi
     wineserver -k 2>/dev/null || true
-    sleep 2
-    echo "[*] Running installer..."
     wine "$INSTALLER" /VERYSILENT /NORESTART 2>/dev/null || true
-    echo "[*] Waiting for installer to finish..."
     for _ in $(seq 1 30); do
-        sleep 2
-        [ -f "$RADMIN_DIR/RvControlSvc.exe" ] && break
+        sleep 0.5
+        [ -f "$RADMIN/RvControlSvc.exe" ] && break
     done
-    if [ ! -f "$RADMIN_DIR/RvControlSvc.exe" ]; then
-        echo "[-] Installer failed — RvControlSvc.exe not found"
+    if [ ! -f "$RADMIN/RvControlSvc.exe" ]; then
+        echo "Erro: instalação falhou"
         exit 1
     fi
     wineserver -k 2>/dev/null || true
-    sleep 1
-    # Remove real NDIS driver (crashes Wine — we replace it with rvpnnetmp.sys)
     wine reg delete "HKLM\\SYSTEM\\CurrentControlSet\\Services\\RvNetMP60" /f > /dev/null 2>&1 || true
     rm -f "$WINEPREFIX/drive_c/windows/system32/drivers/RvNetMP60.sys"
-    # Disable SCM auto-start (we launch via rvpn_launcher /run)
     wine reg add "HKLM\\SYSTEM\\CurrentControlSet\\Services\\RvControlSvc" /v Start /t REG_DWORD /d 4 /f > /dev/null 2>&1 || true
     wineserver -k 2>/dev/null || true
-    sleep 1
-    echo "[+] Radmin VPN installed"
 fi
 
-# 3. Install our components
-echo "[*] Installing components..."
 chmod +x "$BUILD_DIR/tap_bridge" 2>/dev/null || true
 cp "$BUILD_DIR/rvpnnetmp.sys" "$WINEPREFIX/drive_c/windows/system32/drivers/"
-cp "$BUILD_DIR/adapter_hook.dll" "$RADMIN_DIR/"
-cp "$BUILD_DIR/rvpn_launcher.exe" "$RADMIN_DIR/"
+cp "$BUILD_DIR/adapter_hook.dll" "$RADMIN/"
+cp "$BUILD_DIR/rvpn_launcher.exe" "$RADMIN/"
 cp "$BUILD_DIR/netsh.exe" "$WINEPREFIX/drive_c/windows/syswow64/netsh.exe"
-# Neutralize Radmin's bundled NDIS driver installer. At runtime RvControlSvc runs
-# "drvinst.exe install ... NetMP60.inf", which re-installs + loads the real NDIS
-# miniport (NetMP60_1_1_64.sys). That driver aborts Wine in DriverEntry via the
-# unimplemented ndis.sys!NdisInitializeReadWriteLock (issue #12). We replace the
-# whole adapter with rvpnnetmp.sys, so the real driver must never load — overwrite
-# drvinst.exe (invoked by bare name from this dir, so the local copy wins) with a
-# no-op stub that returns success.
-cp "$BUILD_DIR/drvinst.exe" "$RADMIN_DIR/drvinst.exe"
+cp "$BUILD_DIR/netsh64.exe" "$WINEPREFIX/drive_c/windows/system32/netsh.exe"
+# Replace Radmin's real NDIS driver installer with a no-op stub.
+# RvControlSvc runs drvinst.exe at runtime to load NetMP60_1_1_64.sys, which
+# aborts Wine 11.x via NdisInitializeReadWriteLock (issue #12). Our rvpnnetmp.sys
+# replaces that adapter, so the real NDIS driver must never load.
+cp "$BUILD_DIR/drvinst.exe" "$RADMIN/drvinst.exe"
 
-# Scrub any real NDIS driver left behind on an ALREADY-poisoned prefix. The
-# fresh-install block above only deletes RvNetMP60 once; a prefix that ran an
-# older build (or a pre-stub drvinst) already has the service + .sys registered,
-# and Wine's PnP would re-start that demand-start (StartType=3) miniport at the
-# next wineserver boot → NdisInitializeReadWriteLock abort all over again (#12).
-# Run it every launch so a poisoned prefix recovers without a reinstall (which
-# would burn a fresh RID — see ban-risk note). Removing the .sys is the key bit:
-# even if a devnode lingers, a missing image fails the load cleanly instead of
-# aborting. Idempotent — safe on a clean prefix.
+# Scrub any real NDIS driver left behind on a poisoned prefix (run every launch
+# so an already-poisoned prefix recovers without reinstall).
 wine reg delete "HKLM\\SYSTEM\\CurrentControlSet\\Services\\RvNetMP60" /f > /dev/null 2>&1 || true
 rm -f "$WINEPREFIX/drive_c/windows/system32/drivers/RvNetMP60.sys"
 
-# 4. Generate or load persistent adapter MAC
 if [ -f "$MAC_FILE" ]; then
     ADAPTER_MAC=$(cat "$MAC_FILE")
 else
-    # Random locally-administered unicast MAC (02:xx:xx:xx:xx:xx)
     ADAPTER_MAC=$(printf '02:%02x:%02x:%02x:%02x:%02x' \
         $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)))
     echo "$ADAPTER_MAC" > "$MAC_FILE"
-    echo "[+] Generated adapter MAC: $ADAPTER_MAC"
 fi
 # Write raw 6 bytes for driver to read
 printf '%b' "$(echo "$ADAPTER_MAC" | sed 's/://g; s/../\\x&/g')" > /tmp/rvpn_mac
 
-# 5. Create TAP device
-echo "[*] Creating TAP device..."
+sudo modprobe tun 2>/dev/null || true
 sudo ip link delete "$TAP_DEV" 2>/dev/null || true
 sudo ip tuntap add dev "$TAP_DEV" mode tap user "$(whoami)"
 sudo ip link set "$TAP_DEV" address "$ADAPTER_MAC"
 sudo ip link set "$TAP_DEV" up
-echo "[+] TAP $TAP_DEV created (MAC=$ADAPTER_MAC)"
+# Enable multicast support for IGMP/Minecraft LAN
+sudo ip link set "$TAP_DEV" multicast on
+sudo ip link set "$TAP_DEV" allmulticast on
+# Disable reverse-path filtering — VPN peers have IPs from 26.x.x.x but
+# the kernel may not find a matching route back, causing it to drop replies.
+sudo sysctl -w "net.ipv4.conf.$TAP_DEV.rp_filter=0" >/dev/null 2>&1 || true
+sudo sysctl -w "net.ipv4.conf.$TAP_DEV.accept_local=1" >/dev/null 2>&1 || true
+sudo ip maddr add 224.0.2.60 dev "$TAP_DEV" 2>/dev/null || true
+# Prevent NetworkManager/avahi from cycling the VPN adapter's addresses.
+# NM treats the TAP as an external device and periodically re-configures it;
+# each address cycle triggers an NDIS adapter-removal event inside Wine,
+# which causes DispatchCleanup to fire and crash (0xc0000005 in ntdll).
+sudo nmcli device set "$TAP_DEV" managed no 2>/dev/null || true
 
-# 6. Start tap_bridge
-echo "[*] Starting tap_bridge..."
 pkill -f tap_bridge 2>/dev/null || true
-sleep 0.3
 rm -f /tmp/rvpn_b2d /tmp/rvpn_d2b
 "$BUILD_DIR/tap_bridge" > /tmp/radmin_bridge.log 2>&1 &
 BRIDGE_PID=$!
 for _ in $(seq 1 10); do
     [ -p /tmp/rvpn_b2d ] && [ -p /tmp/rvpn_d2b ] && break
-    sleep 0.2
+    sleep 0.1
 done
 if [ ! -p /tmp/rvpn_b2d ] || [ ! -p /tmp/rvpn_d2b ]; then
-    echo "[-] tap_bridge failed to create FIFOs"
+    echo "Erro: falha ao iniciar ponte"
     exit 1
 fi
-echo "[+] tap_bridge running (pid=$BRIDGE_PID)"
 
-# 7. Get TAP GUID from Wine and update registry
-echo "[*] Detecting TAP adapter GUID..."
-TAP_GUID=$(wine wmic path Win32_NetworkAdapter get Name,GUID 2>/dev/null \
+TAP_GUID=$(timeout 10 wine wmic path Win32_NetworkAdapter get Name,GUID \
     | grep "$TAP_DEV" | awk '{print $1}' | tr -d '\r')
 if [ -z "$TAP_GUID" ]; then
-    echo "[-] Could not read TAP GUID from Wine WMI"
-    exit 1
+    TAP_GUID="{$(echo "$ADAPTER_MAC" | sed 's/://g' | md5sum | cut -c1-8)-$(echo "$ADAPTER_MAC" | sed 's/://g' | md5sum | cut -c9-12)-4$(echo "$ADAPTER_MAC" | sed 's/://g' | md5sum | cut -c13-16)-$(echo "$ADAPTER_MAC" | sed 's/://g' | md5sum | cut -c17-20)-$(echo "$ADAPTER_MAC" | sed 's/://g' | md5sum | cut -c21-32)}"
 fi
-echo "[+] TAP GUID: $TAP_GUID"
 
 {
 wine reg add "HKLM\SYSTEM\CurrentControlSet\Control\Class\{4d36e972-e325-11ce-bfc1-08002be10318}\0099" /v NetCfgInstanceId /t REG_SZ /d "$TAP_GUID" /f
@@ -365,11 +285,11 @@ wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v Type /t REG_D
 wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v Group /t REG_SZ /d "NDIS" /f
 wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v ErrorControl /t REG_DWORD /d 0 /f
 } > /dev/null 2>&1
-echo "[+] Registry configured"
 
-# Restart wineserver so it loads the driver on next boot
 wineserver -k 2>/dev/null || true
-sleep 1
+wine reg add "HKLM\\System\\CurrentControlSet\\Control\\Session Manager\\Memory Management" /v SystemPages /t REG_DWORD /d 0xFFFFFFFF /f > /dev/null 2>&1
+wine reg add "HKLM\\System\\CurrentControlSet\\Control\\Session Manager\\Memory Management" /v ClearPageFileAtShutdown /t REG_DWORD /d 0 /f > /dev/null 2>&1
+wine reg add "HKLM\\System\\CurrentControlSet\\Control\\Session Manager\\Memory Management" /v LargeSystemCache /t REG_DWORD /d 1 /f > /dev/null 2>&1
 
 # 8. Start netsh relay
 rm -f "$CMD_FILE" "${CMD_FILE}.proc"
@@ -384,117 +304,142 @@ rm -f "$CMD_FILE" "${CMD_FILE}.proc"
             done < "${CMD_FILE}.proc"
             rm -f "${CMD_FILE}.proc"
         fi
-        sleep 0.3
+        sleep 0.1
     done
 ) &
 RELAY_PID=$!
 
 # 9. Clear old logs
-rm -f "$LOG" "$WINEPREFIX/drive_c/radmin_driver.log"
+rm -f "$LOG" "$WINEPREFIX/drive_c/radmin_driver.log" /tmp/radmin_driver.log
 
-# 10. Start service
-# Force native netsh.exe: wine-staging 11.x prefers its builtin stub even when a native
-# PE sits in syswow64, so our wrapper would be skipped. "n" (native only) is the one-flag
-# fix that restored IP assignment. Deferred to here so the install-phase firewall CA
-# can use Wine's builtin stub (our wrapper doesn't exist until step 3 runs).
-export WINEDLLOVERRIDES="mscoree=;mshtml=;netsh.exe=n"
-echo "[*] Starting Radmin VPN service..."
-cd "$RADMIN_DIR"
-wine rvpn_launcher.exe /run > /tmp/radmin_service.log 2>&1 &
+# Maximum-logging debug mode (RVPN_DEBUG=1): capture service + GUI crash
+# backtraces and a full state bundle on exit. Negligible normal-path overhead
+# (no +relay), so the crash still reproduces with original timing.
+RVPN_DEBUG="${RVPN_DEBUG:-0}"
+if [ "$RVPN_DEBUG" = "1" ]; then
+    rm -f "$WINEPREFIX/drive_c/radmin_crash.log" "$WINEPREFIX/drive_c/radmin_hook_debug.log"
+    # AeDebug: auto-attach winedbg on any unhandled crash (belt-and-suspenders
+    # alongside the in-process vectored handler in adapter_hook.dll).
+    wine reg add "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug" /v Auto     /t REG_SZ /d 1                    /f >/dev/null 2>&1 || true
+    wine reg add "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug" /v Debugger /t REG_SZ /d "winedbg --auto %ld %ld" /f >/dev/null 2>&1 || true
+    # Force GUI under winedbg so RvRvpnGui faults dump a full symbolized bt.
+    RVPN_GUI_WINEDBG=1
+    echo "[*] RVPN_DEBUG=1 — máximo logging ativo (service+GUI crash capture + bundle no exit)"
+fi
 
-# 11. Wait for service ready + extract VPN IP
-echo "[*] Waiting for service ready..."
-SERVICE_START=$(date +%s)
-SERVICE_SEEN=0
-READY=0
+# Force native netsh.exe: wine-staging 11.x prefers its builtin stub even when a
+# native PE sits in syswow64, so our wrapper would be skipped. Deferred to here
+# so the install-phase firewall CA can use Wine's builtin stub (our wrapper
+# doesn't exist until step 3 copies it).
+export WINEDLLOVERRIDES="${WINEDLLOVERRIDES:-mscoree=;mshtml=};netsh.exe=n"
+
+# Note: the CSetupAdapter dangling-INetwork crash (joining a network with many
+# networks active) is fixed at runtime by adapter_hook.dll's release guard
+# (install_release_guard), injected before RvControlSvc starts. No static patch
+# of RvControlSvc.exe is needed.
+
+cd "$RADMIN"
+# Service Wine debug channels: silent by default, +seh backtrace when debugging.
+_svc_winedebug="-all"
+[ "$RVPN_DEBUG" = "1" ] && _svc_winedebug="+seh,+tid,+pid"
+WINEDEBUG="$_svc_winedebug" WINE_LARGE_ADDRESS_AWARE=1 wine rvpn_launcher.exe /run > /tmp/radmin_service.log 2>&1 &
+
 for _ in $(seq 1 60); do
-    sleep 1
+    sleep 0.5
     if [ -f "$LOG" ]; then
         log_txt=$(iconv -f UTF-16LE -t UTF-8 "$LOG" 2>/dev/null || true)
-        # Unsupported-version gate. This project was reverse-engineered against
-        # Radmin VPN 2.0.x. v1.4 registers and opens the adapter but never
-        # reaches "ready" under our shim — it would otherwise hang here until
-        # timeout and then sit at "Connecting..." forever in the GUI.
+        # Radmin VPN 1.4 registers the adapter but never reaches "ready" under
+        # our shim — detect early and bail with a clear message.
         if printf '%s' "$log_txt" | grep -qE 'Service version: *1\.4'; then
             ver=$(printf '%s' "$log_txt" | grep -oE 'Service version: *[0-9.]+' | head -n1)
             echo ""
-            echo "[-] Unsupported Radmin VPN version ($ver)."
-            echo "    This project only works with Radmin VPN 2.0.x — 1.4 never"
-            echo "    finishes connecting under the Wine shim."
-            echo "    Fix: delete the wineprefix and reinstall with a 2.0 build:"
-            echo "      rm -rf \"$WINEPREFIX\""
-            echo "      ./run.sh --installer /path/to/Radmin_VPN_2.0.*.exe"
+            echo "[-] Versão não suportada ($ver). Use Radmin VPN 2.0.x."
+            echo "    rm -rf \"$WINEPREFIX\" && ./run.sh --installer /path/to/Radmin_VPN_2.0.*.exe"
             exit 1
         fi
-        if printf '%s' "$log_txt" | grep -q 'adapter ready'; then
-            vpn_ip=$(printf '%s' "$log_txt" \
-                | grep -E 'Registered as|IP:' \
-                | grep -v '0\.0\.0\.0' \
-                | grep -oE '26\.[0-9]+\.[0-9]+\.[0-9]+' \
-                | tail -n1)
-            if [ -n "$vpn_ip" ]; then
-                echo "[+] VPN IP: $vpn_ip"
-                READY=1
-                break
-            fi
+        vpn_ip=$(printf '%s' "$log_txt" | python3 -c "
+import sys, re
+lines = sys.stdin.read().strip().split('\n')
+has_ready = any('adapter ready' in l for l in lines)
+if has_ready:
+    for l in reversed(lines):
+        if 'Registered as' in l or ('IP:' in l and '0.0.0.0' not in l):
+            m = re.search(r'26\.\d+\.\d+\.\d+', l)
+            if m: print(m.group()); break
+" 2>/dev/null)
+        if [ -n "$vpn_ip" ]; then
+            break
         fi
     fi
-    if pgrep -f RvControlSvc >/dev/null; then
-        SERVICE_SEEN=1
-    else
-        elapsed=$(( $(date +%s) - SERVICE_START ))
-        if [ "$SERVICE_SEEN" = "1" ]; then
-            dump_diagnostics "Service started then died after ${elapsed}s"
-            [ "$DIAG_FAILS" -eq 0 ] && retry_verbose
-            exit 1
-        elif [ "$elapsed" -ge 5 ]; then
-            dump_diagnostics "Service never started (waited ${elapsed}s — launcher or injection failed)"
-            [ "$DIAG_FAILS" -eq 0 ] && retry_verbose
-            exit 1
-        fi
-    fi
+    pgrep -f RvControlSvc >/dev/null || { echo "Erro: serviço encerrado"; exit 1; }
 done
 
-# Ready never reached, but the service is still alive (stuck handshake) —
-# surface it instead of silently launching the GUI into a "Connecting..."
-# dead end. This is the alive-but-not-ready case the death checks above miss.
-if [ "$READY" = "0" ]; then
-    dump_diagnostics "Service alive but never became ready (timed out after $(( $(date +%s) - SERVICE_START ))s)"
-    [ "$DIAG_FAILS" -eq 0 ] && retry_verbose
-    exit 1
+if [ -n "$vpn_ip" ]; then
+    sudo ip addr add "$vpn_ip/8" dev "$TAP_DEV" 2>/dev/null || true
+    sudo ip link set "$TAP_DEV" up 2>/dev/null || true
 fi
-
-# 12. Set up on-link route + broadcast/multicast steering
-# The driver now fans out group-addressed frames (broadcast + IPv4/IPv6
-# multicast) to every connected peer, but the Linux kernel still has to
-# pick our TAP as the egress for those frames. Without these two routes
-# the kernel sends them on the default interface (or nowhere) and games
-# that rely on LAN auto-discovery (broadcast probes, mDNS, SSDP, ...)
-# never see other Radmin peers.
-#
-# Side effect: while the VPN is up, mDNS / Bonjour / SSDP on the local
-# physical LAN go via Radmin instead of eth0/wlan0. Pass
-# --no-broadcast-routes to keep the legacy behaviour.
-sleep 2
 sudo ip route replace 26.0.0.0/8 dev "$TAP_DEV"
-echo "[+] Route: 26.0.0.0/8 dev $TAP_DEV (on-link)"
 if [ "$NO_BCAST_ROUTES" = "0" ]; then
     sudo ip route append 255.255.255.255/32 dev "$TAP_DEV" metric 0 2>/dev/null || true
     sudo ip route append 224.0.0.0/4        dev "$TAP_DEV" metric 0 2>/dev/null || true
-    echo "[+] Routes: limited broadcast + IPv4 multicast → $TAP_DEV (--no-broadcast-routes to skip)"
-else
-    echo "[*] Skipping broadcast/multicast routes (--no-broadcast-routes)"
+    echo "[+] Rotas: broadcast + multicast IPv4 → $TAP_DEV (use --no-broadcast-routes para desativar)"
 fi
-echo ""
-ip addr show "$TAP_DEV" 2>/dev/null | grep -E "inet |state"
-echo ""
 
-# 13. Launch GUI
-echo "[*] Starting GUI..."
-wine "$RADMIN_DIR/RvRvpnGui.exe" > /tmp/radmin_gui.log 2>&1 &
+# Patch Qt's qwindows.dll to survive malformed font name-table offsets that Wine
+# returns for some host fonts (the chat-crash root cause). Idempotent: re-running
+# detects an already-patched dll. Opt-in via --fix-chat.
+if [ "$FIX_CHAT" -eq 1 ]; then
+    if [ -f "$DIR/patch_qwindows_font.py" ] && [ -f "$RADMIN/platforms/qwindows.dll" ]; then
+        python3 "$DIR/patch_qwindows_font.py" "$RADMIN/platforms/qwindows.dll" >/dev/null 2>&1 \
+            && echo "[+] chat fix applied (qwindows.dll patched)" \
+            || echo "[!] warning: qwindows.dll patch failed — chat may crash"
+    fi
+fi
+
+# GUI launch.
+#
+# Chat crash root cause (confirmed via Wine backtrace + IAT disasm): the crash is
+# an access violation (0xc0000005) inside Qt5Core!QString::fromUtf16 at +0x1D, the
+# size<0 NUL-scan path (cmp word [ecx],ax). It is NOT the OpenGL scenegraph -- the
+# app calls fromUtf16/fromWCharArray on a UTF-16 pointer that is non-NULL but
+# points to freed/garbage memory. On Windows that page stays committed (garbage,
+# no crash); under Wine it is unmapped -> fault. See debug knobs below to capture
+# the exact caller.
+#
+#   RVPN_GUI_DEBUG=1    -> un-silence Wine; unhandled exception backtrace to
+#                          /tmp/radmin_gui.log (WINE_GUI_DEBUG overrides channels).
+#   RVPN_GUI_WINEDBG=1  -> run the GUI under `winedbg --auto` so the crash prints a
+#                          FULL symbolized backtrace (module+offset+return addrs)
+#                          to /tmp/radmin_gui.log before run.sh cleanup tears Wine
+#                          down. Use this to identify the crashing call site.
+#   QT_QUICK_BACKEND    -> e.g. "software" to force raster (unrelated to this bug,
+#                          left unset by default now).
+[ -n "${QT_QUICK_BACKEND:-}" ] && export QT_QUICK_BACKEND
+_gui_winedebug="-all"
+if [ "${RVPN_GUI_DEBUG:-0}" = "1" ]; then
+    _gui_winedebug="${WINE_GUI_DEBUG:-+seh,+tid}"
+fi
+if [ "${RVPN_GUI_WINEDBG:-0}" = "1" ]; then
+    # Batch-drive winedbg over stdin: "c" runs the GUI; on an unhandled fault
+    # winedbg regains control and we dump backtraces, then quit. Captures the
+    # crashing call site (module+offset+return addresses) to /tmp/radmin_gui.log.
+    printf 'c\ninfo share\nbt\nbt all\nquit\n' \
+        | WINEDEBUG=-all winedbg "C:\\Program Files (x86)\\Radmin VPN\\RvRvpnGui.exe" \
+        > /tmp/radmin_gui.log 2>&1 &
+else
+    LIBGL_ALWAYS_SOFTWARE=1 GALLIUM_DRIVER=llvmpipe \
+        WINEDEBUG="$_gui_winedebug" \
+        wine RvRvpnGui.exe > /tmp/radmin_gui.log 2>&1 &
+fi
 GUI_PID=$!
 
-echo "[+] Radmin VPN running. Close the GUI or press Ctrl+C to stop."
-echo ""
+# Packet-filter UI is opt-in via --filter-ui (and never with --no-ui).
+if [ "$FILTER_UI" -eq 1 ] && [ "$NO_UI" -eq 0 ] && [ -x "$BUILD_DIR/rvpn_filter_ui" ]; then
+    "$BUILD_DIR/rvpn_filter_ui" > /tmp/radmin_filter_ui.log 2>&1 &
+    FILTER_UI_PID=$!
+fi
+
+echo "Radmin VPN - service active"
+
 
 wait $GUI_PID || true

--- a/run_datacenter.sh
+++ b/run_datacenter.sh
@@ -1,0 +1,438 @@
+#!/bin/bash
+# run_datacenter.sh - Radmin VPN Datacenter Edition
+# Runs on headless VPS (no display server) using Xvfb + noVNC for web-based GUI access
+# Usage: ./run_datacenter.sh [--installer /path/to/Radmin_VPN_*.exe] [--vnc-port PORT] [--web-port PORT] [--vnc-password PASS]
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+_distro() {
+    if command -v dnf      >/dev/null 2>&1; then printf 'fedora'
+    elif command -v apt-get >/dev/null 2>&1; then printf 'debian'
+    elif command -v pacman  >/dev/null 2>&1; then printf 'arch'
+    elif command -v zypper  >/dev/null 2>&1; then printf 'suse'
+    else printf 'unknown'; fi
+}
+
+_wine_install_hint() {
+    case "$(_distro)" in
+        fedora)  echo "  sudo dnf install wine winetricks" ;;
+        debian)  echo "  sudo apt install wine winetricks" ;;
+        arch)    echo "  sudo pacman -S wine winetricks" ;;
+        suse)    echo "  sudo zypper install wine winetricks" ;;
+        *)       echo "  Install wine from: https://www.winehq.org/" ;;
+    esac
+}
+
+export WINEPREFIX="$DIR/wineprefix"
+RADMIN="$WINEPREFIX/drive_c/Program Files (x86)/Radmin VPN"
+BUILD_DIR="$DIR/build"
+TAP_DEV="radminvpn0"
+CMD_FILE="/tmp/radmin_netsh_cmd"
+LOG="$WINEPREFIX/drive_c/ProgramData/Famatech/Radmin VPN/service.log"
+MAC_FILE="$WINEPREFIX/radmin_mac"
+GUID_FILE="$WINEPREFIX/radmin_guid"
+
+# Virtual display settings
+VNC_DISPLAY=:99
+VNC_PORT=5900
+WEB_PORT=6080
+VNC_PASSWORD=""
+NOVNC_PATH=""
+
+# PIDs for cleanup
+XVFB_PID=""
+X11VNC_PID=""
+WEBSOCKIFY_PID=""
+RELAY_PID=""
+BRIDGE_PID=""
+GUI_PID=""
+
+# Parse args
+INSTALLER=""
+for arg in "$@"; do
+    case "$arg" in
+        --installer) shift; INSTALLER="$1"; shift ;;
+        --installer=*) INSTALLER="${arg#*=}" ;;
+        --vnc-port) shift; VNC_PORT="$1"; shift ;;
+        --vnc-port=*) VNC_PORT="${arg#*=}" ;;
+        --web-port) shift; WEB_PORT="$1"; shift ;;
+        --web-port=*) WEB_PORT="${arg#*=}" ;;
+        --vnc-password) shift; VNC_PASSWORD="$1"; shift ;;
+        --vnc-password=*) VNC_PASSWORD="${arg#*=}" ;;
+    esac
+done
+
+# Find installer if not specified
+if [ -z "$INSTALLER" ]; then
+    INSTALLER=$(find "$DIR" -maxdepth 1 -name "Radmin_VPN_*.exe" -print -quit 2>/dev/null || true)
+fi
+
+cleanup() {
+    echo "[*] Stopping datacenter edition..."
+    [ -n "$GUI_PID" ] && kill "$GUI_PID" 2>/dev/null || true
+    wineserver -k 2>/dev/null || true
+    sleep 1
+    [ -n "$BRIDGE_PID" ] && kill "$BRIDGE_PID" 2>/dev/null || true
+    [ -n "$RELAY_PID" ] && kill "$RELAY_PID" 2>/dev/null || true
+    [ -n "$WEBSOCKIFY_PID" ] && kill "$WEBSOCKIFY_PID" 2>/dev/null || true
+    [ -n "$X11VNC_PID" ] && kill "$X11VNC_PID" 2>/dev/null || true
+    [ -n "$XVFB_PID" ] && kill "$XVFB_PID" 2>/dev/null || true
+    sudo ip link delete "$TAP_DEV" 2>/dev/null || true
+    rm -f "$CMD_FILE" "${CMD_FILE}.proc" /tmp/rvpn_b2d /tmp/rvpn_d2b /tmp/rvpn_mac /tmp/rvpn_filters.json
+    rm -f /tmp/rvpn_vnc_password /tmp/.X${VNC_DISPLAY#:}-lock
+    echo "[*] Done"
+}
+trap cleanup EXIT
+
+echo "[*] Radmin VPN Datacenter Edition"
+echo "    Virtual display + web-based GUI access"
+echo ""
+
+# ── Prerequisites ──
+_missing=""
+command -v wine       >/dev/null || _missing="$_missing wine"
+command -v wineserver >/dev/null || _missing="$_missing wineserver"
+command -v python3    >/dev/null || _missing="$_missing python3"
+command -v ip         >/dev/null || _missing="$_missing ip(iproute2)"
+if [ -n "$_missing" ]; then
+    echo "[-] Missing dependencies:$_missing"
+    _wine_install_hint
+    exit 1
+fi
+sudo -v || { echo "[-] Need sudo for TAP device."; exit 1; }
+
+if command -v getenforce >/dev/null 2>&1 && [ "$(getenforce 2>/dev/null)" = "Enforcing" ]; then
+    echo "[!] SELinux Enforcing detected. If failures occur, try:"
+    echo "    sudo setsebool -P allow_execmod on"
+    echo "    sudo chcon -t bin_t \"$BUILD_DIR/tap_bridge\""
+fi
+
+# Check for virtual display components
+MISSING_DC=()
+command -v Xvfb >/dev/null || MISSING_DC+=("xvfb")
+command -v x11vnc >/dev/null || MISSING_DC+=("x11vnc")
+command -v websockify >/dev/null || MISSING_DC+=("websockify")
+
+if [ ${#MISSING_DC[@]} -gt 0 ]; then
+    echo "[-] Missing datacenter components: ${MISSING_DC[*]}"
+    echo "    Install with:"
+    echo "      sudo apt install -y xvfb x11vnc websockify"
+    echo "    Or run: make install-datacenter-deps"
+    exit 1
+fi
+
+# Find noVNC web directory (path varies by distro and version)
+for p in \
+    /usr/share/novnc \
+    /usr/share/novnc/www \
+    /usr/share/websockify/novnc \
+    /usr/lib/novnc \
+    /usr/lib/novnc/web \
+    /usr/share/webapps/novnc; do
+    if [ -d "$p" ] && { [ -f "$p/vnc.html" ] || [ -f "$p/vnc_lite.html" ]; }; then
+        NOVNC_PATH="$p"
+        break
+    fi
+done
+if [ -z "$NOVNC_PATH" ]; then
+    echo "[-] noVNC web files not found. Install:"
+    case "$(_distro)" in
+        fedora) echo "    sudo dnf install novnc" ;;
+        debian) echo "    sudo apt install -y novnc" ;;
+        arch)   echo "    yay -S novnc  # AUR" ;;
+        *)      echo "    https://novnc.com" ;;
+    esac
+    exit 1
+fi
+
+# ── 1. Kill any previous session ──
+wineserver -k 2>/dev/null || true
+# Kill leftover Xvfb on our display
+if [ -f "/tmp/.X${VNC_DISPLAY#:}-lock" ]; then
+    OLD_XVFB_PID=$(cat "/tmp/.X${VNC_DISPLAY#:}-lock" 2>/dev/null | tr -d ' ')
+    [ -n "$OLD_XVFB_PID" ] && kill "$OLD_XVFB_PID" 2>/dev/null || true
+    rm -f "/tmp/.X${VNC_DISPLAY#:}-lock"
+    sleep 1
+fi
+sleep 1
+
+# ── 2. Start Xvfb (virtual display) ──
+echo "[*] Starting virtual display (Xvfb $VNC_DISPLAY)..."
+Xvfb "$VNC_DISPLAY" -screen 0 1280x720x24 -ac +extension GLX +render -noreset > /tmp/radmin_xvfb.log 2>&1 &
+XVFB_PID=$!
+sleep 1
+
+# Verify Xvfb started
+if ! kill -0 "$XVFB_PID" 2>/dev/null; then
+    echo "[-] Xvfb failed to start. Check /tmp/radmin_xvfb.log"
+    exit 1
+fi
+echo "[+] Xvfb running (pid=$XVFB_PID, display=$VNC_DISPLAY)"
+
+# Set DISPLAY for all Wine processes
+export DISPLAY="$VNC_DISPLAY"
+
+# ── 3. Start x11vnc (VNC server) ──
+echo "[*] Starting VNC server on port $VNC_PORT..."
+VNC_ARGS=(-display "$VNC_DISPLAY" -forever -shared -rfbport "$VNC_PORT" -nopw)
+
+if [ -n "$VNC_PASSWORD" ]; then
+    # Write password file for x11vnc
+    x11vnc -storepasswd "$VNC_PASSWORD" /tmp/rvpn_vnc_password 2>/dev/null
+    VNC_ARGS+=(-rfbauth /tmp/rvpn_vnc_password)
+    echo "[+] VNC password set"
+else
+    echo "[!] WARNING: VNC has no password. Use --vnc-password for security."
+fi
+
+x11vnc "${VNC_ARGS[@]}" > /tmp/radmin_x11vnc.log 2>&1 &
+X11VNC_PID=$!
+sleep 1
+
+if ! kill -0 "$X11VNC_PID" 2>/dev/null; then
+    echo "[-] x11vnc failed to start. Check /tmp/radmin_x11vnc.log"
+    exit 1
+fi
+echo "[+] VNC server running (pid=$X11VNC_PID, port=$VNC_PORT)"
+
+# ── 4. Start noVNC (web-based VNC client) ──
+echo "[*] Starting noVNC on port $WEB_PORT..."
+websockify --web="$NOVNC_PATH" 0.0.0.0:"$WEB_PORT" localhost:"$VNC_PORT" > /tmp/radmin_novnc.log 2>&1 &
+WEBSOCKIFY_PID=$!
+sleep 1
+
+if ! kill -0 "$WEBSOCKIFY_PID" 2>/dev/null; then
+    echo "[-] websockify/noVNC failed to start. Check /tmp/radmin_novnc.log"
+    exit 1
+fi
+
+# Detect the right HTML file
+NOVNC_HTML="vnc.html"
+[ -f "$NOVNC_PATH/vnc_lite.html" ] && NOVNC_HTML="vnc_lite.html"
+
+echo "[+] noVNC running (pid=$WEBSOCKIFY_PID, port=$WEB_PORT)"
+echo ""
+EXTERNAL_IP=$(hostname -I 2>/dev/null | awk '{print $1}' || echo "YOUR_VPS_IP")
+echo "    ┌──────────────────────────────────────────────────────┐"
+echo "    │  Open in browser to access Radmin VPN GUI:         │"
+echo "    │  http://$EXTERNAL_IP:$WEB_PORT/$NOVNC_HTML   │"
+echo "    └──────────────────────────────────────────────────────┘"
+echo ""
+
+# ── 5. Install Radmin if not present ──
+if [ ! -f "$RADMIN/RvControlSvc.exe" ]; then
+    if [ -z "$INSTALLER" ] || [ ! -f "$INSTALLER" ]; then
+        echo "[-] Radmin VPN not installed and no installer found."
+        echo "    Download from https://www.radmin-vpn.com/ and run:"
+        echo "    ./run_datacenter.sh --installer /path/to/Radmin_VPN_*.exe"
+        exit 1
+    fi
+    echo "[*] Installing Radmin VPN..."
+    mkdir -p "$WINEPREFIX"
+    wineboot --init 2>/dev/null
+    echo "[+] Wine prefix created"
+    wineserver -k 2>/dev/null || true
+    sleep 2
+    echo "[*] Running installer..."
+    wine "$INSTALLER" /VERYSILENT /NORESTART 2>/dev/null || true
+    echo "[*] Waiting for installer to finish..."
+    for _ in $(seq 1 30); do
+        sleep 2
+        [ -f "$RADMIN/RvControlSvc.exe" ] && break
+    done
+    if [ ! -f "$RADMIN/RvControlSvc.exe" ]; then
+        echo "[-] Installer failed — RvControlSvc.exe not found"
+        exit 1
+    fi
+    wineserver -k 2>/dev/null || true
+    sleep 1
+    # Remove real NDIS driver (crashes Wine — we replace it with rvpnnetmp.sys)
+    wine reg delete "HKLM\\SYSTEM\\CurrentControlSet\\Services\\RvNetMP60" /f > /dev/null 2>&1 || true
+    rm -f "$WINEPREFIX/drive_c/windows/system32/drivers/RvNetMP60.sys"
+    # Disable SCM auto-start (we launch via rvpn_launcher /run)
+    wine reg add "HKLM\\SYSTEM\\CurrentControlSet\\Services\\RvControlSvc" /v Start /t REG_DWORD /d 4 /f > /dev/null 2>&1 || true
+    wineserver -k 2>/dev/null || true
+    sleep 1
+    echo "[+] Radmin VPN installed"
+fi
+
+# ── 6. Install our components ──
+echo "[*] Installing components..."
+chmod +x "$BUILD_DIR/tap_bridge" 2>/dev/null || true
+cp "$BUILD_DIR/rvpnnetmp.sys" "$WINEPREFIX/drive_c/windows/system32/drivers/"
+cp "$BUILD_DIR/adapter_hook.dll" "$RADMIN/"
+cp "$BUILD_DIR/rvpn_launcher.exe" "$RADMIN/"
+cp "$BUILD_DIR/netsh.exe" "$WINEPREFIX/drive_c/windows/syswow64/netsh.exe"
+cp "$BUILD_DIR/netsh64.exe" "$WINEPREFIX/drive_c/windows/system32/netsh.exe"
+
+# ── 7. Generate or load persistent adapter MAC ──
+if [ -f "$MAC_FILE" ]; then
+    ADAPTER_MAC=$(cat "$MAC_FILE")
+else
+    # Random locally-administered unicast MAC (02:xx:xx:xx:xx:xx)
+    ADAPTER_MAC=$(printf '02:%02x:%02x:%02x:%02x:%02x' \
+        $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)))
+    echo "$ADAPTER_MAC" > "$MAC_FILE"
+    echo "[+] Generated adapter MAC: $ADAPTER_MAC"
+fi
+# Write raw 6 bytes for driver to read
+printf '%b' "$(echo "$ADAPTER_MAC" | sed 's/://g; s/../\\x&/g')" > /tmp/rvpn_mac
+
+# ── 8. Create TAP device ──
+echo "[*] Creating TAP device..."
+sudo modprobe tun 2>/dev/null || true
+sudo ip link delete "$TAP_DEV" 2>/dev/null || true
+sudo ip tuntap add dev "$TAP_DEV" mode tap user "$(whoami)"
+sudo ip link set "$TAP_DEV" address "$ADAPTER_MAC"
+sudo ip link set "$TAP_DEV" up
+# Enable multicast support for IGMP/Minecraft LAN
+sudo ip link set "$TAP_DEV" multicast on
+sudo ip link set "$TAP_DEV" allmulticast on
+# Disable reverse-path filtering — VPN peers have IPs from 26.x.x.x but
+# the kernel may not find a matching route back, causing it to drop replies.
+sudo sysctl -w "net.ipv4.conf.$TAP_DEV.rp_filter=0" >/dev/null 2>&1 || true
+sudo sysctl -w "net.ipv4.conf.$TAP_DEV.accept_local=1" >/dev/null 2>&1 || true
+# Manually join Minecraft LAN multicast group to trigger IGMP membership reports
+sudo ip maddr add 224.0.2.60 dev "$TAP_DEV" 2>/dev/null || true
+echo "[+] TAP $TAP_DEV created (MAC=$ADAPTER_MAC)"
+
+# ── 9. Start tap_bridge ──
+echo "[*] Starting tap_bridge..."
+pkill -f tap_bridge 2>/dev/null || true
+sleep 0.3
+rm -f /tmp/rvpn_b2d /tmp/rvpn_d2b
+"$BUILD_DIR/tap_bridge" > /tmp/radmin_bridge.log 2>&1 &
+BRIDGE_PID=$!
+for _ in $(seq 1 10); do
+    [ -p /tmp/rvpn_b2d ] && [ -p /tmp/rvpn_d2b ] && break
+    sleep 0.2
+done
+if [ ! -p /tmp/rvpn_b2d ] || [ ! -p /tmp/rvpn_d2b ]; then
+    echo "[-] tap_bridge failed to create FIFOs"
+    exit 1
+fi
+echo "[+] tap_bridge running (pid=$BRIDGE_PID)"
+
+# ── 10. Generate or load persistent TAP GUID ──
+echo "[*] Detecting TAP adapter GUID..."
+if [ -f "$GUID_FILE" ]; then
+    TAP_GUID=$(cat "$GUID_FILE")
+else
+    # Generate a random GUID (format: {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx})
+    TAP_GUID=$(printf '{%08x-%04x-%04x-%04x-%012x}' \
+        $((RANDOM%4294967296)) $((RANDOM%65536)) $((RANDOM%65536)) \
+        $((RANDOM%65536)) $((RANDOM%281474976710656)))
+    echo "$TAP_GUID" > "$GUID_FILE"
+    echo "[+] Generated TAP GUID: $TAP_GUID"
+fi
+echo "[+] TAP GUID: $TAP_GUID"
+
+{
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Control\Class\{4d36e972-e325-11ce-bfc1-08002be10318}\0099" /v NetCfgInstanceId /t REG_SZ /d "$TAP_GUID" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Control\Class\{4d36e972-e325-11ce-bfc1-08002be10318}\0099" /v MatchingDeviceId /t REG_SZ /d "${TAP_GUID}\\RvNetMP60" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Control\Network\{4d36e972-e325-11ce-bfc1-08002be10318}\\${TAP_GUID}\Connection" /v Name /t REG_SZ /d "Radmin VPN" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Control\Network\{4d36e972-e325-11ce-bfc1-08002be10318}\\${TAP_GUID}\Connection" /v PnpInstanceID /t REG_SZ /d "ROOT\NET\0099" /f
+wine reg add "HKLM\Software\Wow6432Node\Famatech\RadminVPN\1.0\Firewall" /v AdapterId /t REG_SZ /d "$TAP_GUID" /f
+wine reg add "HKLM\SOFTWARE\Famatech\RadminVPN\1.0\Registration" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v DisplayName /t REG_SZ /d "Radmin VPN TAP Bridge" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v ImagePath /t REG_EXPAND_SZ /d "C:\windows\system32\drivers\rvpnnetmp.sys" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v Start /t REG_DWORD /d 2 /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v Type /t REG_DWORD /d 1 /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v Group /t REG_SZ /d "NDIS" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v ErrorControl /t REG_DWORD /d 0 /f
+} > /dev/null 2>&1
+echo "[+] Registry configured"
+
+# Restart wineserver so it loads the driver on next boot
+wineserver -k 2>/dev/null || true
+sleep 1
+
+# ── 11. Start netsh relay ──
+rm -f "$CMD_FILE" "${CMD_FILE}.proc"
+(
+    while true; do
+        if [ -f "$CMD_FILE" ]; then
+            mv "$CMD_FILE" "${CMD_FILE}.proc" 2>/dev/null || continue
+            while IFS= read -r cmd; do
+                cmd=$(printf '%s' "$cmd" | tr -d '\r')
+                [ -z "$cmd" ] && continue
+                sudo sh -c "$cmd" 2>/dev/null
+            done < "${CMD_FILE}.proc"
+            rm -f "${CMD_FILE}.proc"
+        fi
+        sleep 0.3
+    done
+) &
+RELAY_PID=$!
+
+# ── 12. Clear old logs ──
+rm -f "$LOG" "$WINEPREFIX/drive_c/radmin_driver.log"
+
+# ── 13. Start service ──
+echo "[*] Starting Radmin VPN service..."
+cd "$RADMIN"
+wine rvpn_launcher.exe /run > /tmp/radmin_service.log 2>&1 &
+
+# ── 14. Wait for service ready + extract VPN IP ──
+echo "[*] Waiting for service ready..."
+for _ in $(seq 1 60); do
+    sleep 1
+    if [ -f "$LOG" ]; then
+        vpn_ip=$(python3 -c "
+with open('$LOG', 'rb') as f:
+    t = f.read().decode('utf-16-le', errors='replace')
+lines = t.strip().split('\n')
+has_ready = any('adapter ready' in l for l in lines)
+if has_ready:
+    for l in reversed(lines):
+        if 'Registered as' in l or ('IP:' in l and '0.0.0.0' not in l):
+            import re
+            m = re.search(r'26\.\d+\.\d+\.\d+', l)
+            if m: print(m.group()); break
+" 2>/dev/null)
+        if [ -n "$vpn_ip" ]; then
+            echo "[+] VPN IP: $vpn_ip"
+            break
+        fi
+    fi
+    pgrep -f RvControlSvc >/dev/null || { echo "[-] Service died"; exit 1; }
+done
+
+# ── 15. Assign VPN IP to TAP device + set up route ──
+sleep 2
+if [ -n "$vpn_ip" ]; then
+    # Explicitly assign the VPN IP (fallback if netsh_wrapper wasn't invoked)
+    sudo ip addr add "$vpn_ip/8" dev "$TAP_DEV" 2>/dev/null || true
+    sudo ip link set "$TAP_DEV" up 2>/dev/null || true
+    echo "[+] TAP IP: $vpn_ip/8"
+fi
+sudo ip route replace 26.0.0.0/8 dev "$TAP_DEV"
+echo "[+] Route: 26.0.0.0/8 dev $TAP_DEV (on-link)"
+echo ""
+ip addr show "$TAP_DEV" 2>/dev/null | grep -E "inet |state"
+echo ""
+
+# ── 16. Launch GUI (on virtual display, accessible via noVNC) ──
+echo "[*] Starting Radmin VPN GUI on virtual display..."
+wine RvRvpnGui.exe > /tmp/radmin_gui.log 2>&1 &
+GUI_PID=$!
+echo "[+] GUI running on display $VNC_DISPLAY (pid=$GUI_PID)"
+
+
+echo ""
+echo "[+] ═══════════════════════════════════════════════════════════"
+echo "[+]  Radmin VPN Datacenter Edition is running"
+echo "[+] "
+echo "[+]  VPN IP:  ${vpn_ip:-unknown}"
+echo "[+]  Web GUI: http://$EXTERNAL_IP:$WEB_PORT/$NOVNC_HTML"
+echo "[+]  VNC:     localhost:$VNC_PORT"
+echo "[+] "
+echo "[+]  Configure your networks via the web GUI."
+echo "[+]  After config, the wineprefix can be exported for"
+echo "[+]  headless deployment with run_nogui.sh."
+echo "[+] ═══════════════════════════════════════════════════════════"
+echo ""
+
+# Wait for GUI to exit (or Ctrl+C)
+wait $GUI_PID || true

--- a/run_vps.sh
+++ b/run_vps.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+# run_vps.sh - Radmin VPN on Linux for VPS (headless, hardcoded GUID)
+# Starts service, waits for ready, then launches rv_net_enum.exe
+# Usage: ./run_vps.sh [--installer /path/to/Radmin_VPN_*.exe]
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+export WINEPREFIX="$DIR/wineprefix"
+RADMIN="$WINEPREFIX/drive_c/Program Files (x86)/Radmin VPN"
+BUILD_DIR="$DIR/build"
+TAP_DEV="radminvpn0"
+CMD_FILE="/tmp/radmin_netsh_cmd"
+LOG="$WINEPREFIX/drive_c/ProgramData/Famatech/Radmin VPN/service.log"
+MAC_FILE="$WINEPREFIX/radmin_mac"
+CUSTOM_GUI="$DIR/../rv_net_enum.exe"
+RELAY_PID=""
+BRIDGE_PID=""
+FILTER_UI_PID=""
+
+# Hardcoded TAP GUID for VPS (no Wine WMI required)
+TAP_GUID="{0000000B-0000-0000-0000-4E6574446576}"
+
+# Parse args
+INSTALLER=""
+for arg in "$@"; do
+    case "$arg" in
+        --installer) shift; INSTALLER="$1"; shift ;;
+        --installer=*) INSTALLER="${arg#*=}" ;;
+    esac
+done
+
+# Find installer if not specified
+if [ -z "$INSTALLER" ]; then
+    INSTALLER=$(find "$DIR" -maxdepth 1 -name "Radmin_VPN_*.exe" -print -quit 2>/dev/null || true)
+fi
+
+cleanup() {
+    echo "[*] Stopping..."
+    [ -n "$FILTER_UI_PID" ] && kill "$FILTER_UI_PID" 2>/dev/null || true
+    wineserver -k 2>/dev/null || true
+    sleep 1
+    [ -n "$BRIDGE_PID" ] && kill "$BRIDGE_PID" 2>/dev/null || true
+    [ -n "$RELAY_PID" ] && kill "$RELAY_PID" 2>/dev/null || true
+    sudo ip link delete "$TAP_DEV" 2>/dev/null || true
+    rm -f "$CMD_FILE" "${CMD_FILE}.proc" /tmp/rvpn_b2d /tmp/rvpn_d2b /tmp/rvpn_mac /tmp/rvpn_filters.json
+    echo "[*] Done"
+}
+trap cleanup EXIT
+
+echo "[*] Radmin VPN for Linux (headless service + custom GUI)"
+
+# Prerequisites
+command -v wine >/dev/null || { echo "[-] Wine not found. Install wine."; exit 1; }
+command -v wineserver >/dev/null || { echo "[-] wineserver not found."; exit 1; }
+command -v python3 >/dev/null || { echo "[-] python3 not found."; exit 1; }
+sudo -v || { echo "[-] Need sudo for TAP device."; exit 1; }
+
+# 1. Kill any previous Wine session
+wineserver -k 2>/dev/null || true
+sleep 1
+
+# 2. Install Radmin if not present
+if [ ! -f "$RADMIN/RvControlSvc.exe" ]; then
+    if [ -z "$INSTALLER" ] || [ ! -f "$INSTALLER" ]; then
+        echo "[-] Radmin VPN not installed and no installer found."
+        echo "    Download from https://www.radmin-vpn.com/ and run:"
+        echo "    ./run_vps.sh --installer /path/to/Radmin_VPN_*.exe"
+        exit 1
+    fi
+    echo "[*] Installing Radmin VPN..."
+    mkdir -p "$WINEPREFIX"
+    wineboot --init 2>/dev/null
+    echo "[+] Wine prefix created"
+    wineserver -k 2>/dev/null || true
+    sleep 2
+    echo "[*] Running installer..."
+    wine "$INSTALLER" /VERYSILENT /NORESTART 2>/dev/null || true
+    echo "[*] Waiting for installer to finish..."
+    for _ in $(seq 1 30); do
+        sleep 2
+        [ -f "$RADMIN/RvControlSvc.exe" ] && break
+    done
+    if [ ! -f "$RADMIN/RvControlSvc.exe" ]; then
+        echo "[-] Installer failed — RvControlSvc.exe not found"
+        exit 1
+    fi
+    wineserver -k 2>/dev/null || true
+    sleep 1
+    # Remove real NDIS driver (crashes Wine — we replace it with rvpnnetmp.sys)
+    wine reg delete "HKLM\\SYSTEM\\CurrentControlSet\\Services\\RvNetMP60" /f > /dev/null 2>&1 || true
+    rm -f "$WINEPREFIX/drive_c/windows/system32/drivers/RvNetMP60.sys"
+    # Disable SCM auto-start (we launch via rvpn_launcher /run)
+    wine reg add "HKLM\\SYSTEM\\CurrentControlSet\\Services\\RvControlSvc" /v Start /t REG_DWORD /d 4 /f > /dev/null 2>&1 || true
+    wineserver -k 2>/dev/null || true
+    sleep 1
+    echo "[+] Radmin VPN installed"
+fi
+
+# 3. Install our components
+echo "[*] Installing components..."
+chmod +x "$BUILD_DIR/tap_bridge" 2>/dev/null || true
+cp "$BUILD_DIR/rvpnnetmp.sys" "$WINEPREFIX/drive_c/windows/system32/drivers/"
+cp "$BUILD_DIR/adapter_hook.dll" "$RADMIN/"
+cp "$BUILD_DIR/rvpn_launcher.exe" "$RADMIN/"
+cp "$BUILD_DIR/netsh.exe" "$WINEPREFIX/drive_c/windows/syswow64/netsh.exe"
+cp "$BUILD_DIR/netsh64.exe" "$WINEPREFIX/drive_c/windows/system32/netsh.exe"
+
+# 4. Generate or load persistent adapter MAC
+if [ -f "$MAC_FILE" ]; then
+    ADAPTER_MAC=$(cat "$MAC_FILE")
+else
+    # Random locally-administered unicast MAC (02:xx:xx:xx:xx:xx)
+    ADAPTER_MAC=$(printf '02:%02x:%02x:%02x:%02x:%02x' \
+        $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)))
+    echo "$ADAPTER_MAC" > "$MAC_FILE"
+    echo "[+] Generated adapter MAC: $ADAPTER_MAC"
+fi
+# Write raw 6 bytes for driver to read
+printf '%b' "$(echo "$ADAPTER_MAC" | sed 's/://g; s/../\\x&/g')" > /tmp/rvpn_mac
+
+# 5. Create TAP device
+echo "[*] Creating TAP device..."
+sudo ip link delete "$TAP_DEV" 2>/dev/null || true
+sudo ip tuntap add dev "$TAP_DEV" mode tap user "$(whoami)"
+sudo ip link set "$TAP_DEV" address "$ADAPTER_MAC"
+sudo ip link set "$TAP_DEV" up
+# Enable multicast support for IGMP/Minecraft LAN
+sudo ip link set "$TAP_DEV" multicast on
+sudo ip link set "$TAP_DEV" allmulticast on
+# Disable reverse-path filtering — VPN peers have IPs from 26.x.x.x but
+# the kernel may not find a matching route back, causing it to drop replies.
+sudo sysctl -w "net.ipv4.conf.$TAP_DEV.rp_filter=0" >/dev/null 2>&1 || true
+sudo sysctl -w "net.ipv4.conf.$TAP_DEV.accept_local=1" >/dev/null 2>&1 || true
+# Manually join Minecraft LAN multicast group to trigger IGMP membership reports
+sudo ip maddr add 224.0.2.60 dev "$TAP_DEV" 2>/dev/null || true
+echo "[+] TAP $TAP_DEV created (MAC=$ADAPTER_MAC)"
+
+# 6. Start tap_bridge
+echo "[*] Starting tap_bridge..."
+pkill -f tap_bridge 2>/dev/null || true
+sleep 0.3
+rm -f /tmp/rvpn_b2d /tmp/rvpn_d2b
+"$BUILD_DIR/tap_bridge" > /tmp/radmin_bridge.log 2>&1 &
+BRIDGE_PID=$!
+for _ in $(seq 1 10); do
+    [ -p /tmp/rvpn_b2d ] && [ -p /tmp/rvpn_d2b ] && break
+    sleep 0.2
+done
+if [ ! -p /tmp/rvpn_b2d ] || [ ! -p /tmp/rvpn_d2b ]; then
+    echo "[-] tap_bridge failed to create FIFOs"
+    exit 1
+fi
+echo "[+] tap_bridge running (pid=$BRIDGE_PID)"
+
+# 7. Use hardcoded TAP GUID and update registry
+echo "[*] Using hardcoded TAP GUID: $TAP_GUID"
+
+{
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Control\Class\{4d36e972-e325-11ce-bfc1-08002be10318}\0099" /v NetCfgInstanceId /t REG_SZ /d "$TAP_GUID" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Control\Class\{4d36e972-e325-11ce-bfc1-08002be10318}\0099" /v MatchingDeviceId /t REG_SZ /d "${TAP_GUID}\\RvNetMP60" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Control\Network\{4d36e972-e325-11ce-bfc1-08002be10318}\\${TAP_GUID}\Connection" /v Name /t REG_SZ /d "Radmin VPN" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Control\Network\{4d36e972-e325-11ce-bfc1-08002be10318}\\${TAP_GUID}\Connection" /v PnpInstanceID /t REG_SZ /d "ROOT\NET\0099" /f
+wine reg add "HKLM\Software\Wow6432Node\Famatech\RadminVPN\1.0\Firewall" /v AdapterId /t REG_SZ /d "$TAP_GUID" /f
+wine reg add "HKLM\SOFTWARE\Famatech\RadminVPN\1.0\Registration" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v DisplayName /t REG_SZ /d "Radmin VPN TAP Bridge" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v ImagePath /t REG_EXPAND_SZ /d "C:\windows\system32\drivers\rvpnnetmp.sys" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v Start /t REG_DWORD /d 2 /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v Type /t REG_DWORD /d 1 /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v Group /t REG_SZ /d "NDIS" /f
+wine reg add "HKLM\SYSTEM\CurrentControlSet\Services\rvpnnetmp" /v ErrorControl /t REG_DWORD /d 0 /f
+} > /dev/null 2>&1
+echo "[+] Registry configured"
+
+# Restart wineserver so it loads the driver on next boot
+wineserver -k 2>/dev/null || true
+sleep 1
+
+# 8. Start netsh relay
+rm -f "$CMD_FILE" "${CMD_FILE}.proc"
+(
+    while true; do
+        if [ -f "$CMD_FILE" ]; then
+            mv "$CMD_FILE" "${CMD_FILE}.proc" 2>/dev/null || continue
+            while IFS= read -r cmd; do
+                cmd=$(printf '%s' "$cmd" | tr -d '\r')
+                [ -z "$cmd" ] && continue
+                sudo sh -c "$cmd" 2>/dev/null
+            done < "${CMD_FILE}.proc"
+            rm -f "${CMD_FILE}.proc"
+        fi
+        sleep 0.3
+    done
+) &
+RELAY_PID=$!
+
+# 9. Clear old logs
+rm -f "$LOG" "$WINEPREFIX/drive_c/radmin_driver.log"
+
+# 10. Start service (no original GUI)
+echo "[*] Starting Radmin VPN service (headless)..."
+cd "$RADMIN"
+wine rvpn_launcher.exe /run > /tmp/radmin_service.log 2>&1 &
+
+# 11. Wait for service ready + extract VPN IP
+echo "[*] Waiting for service ready..."
+for _ in $(seq 1 60); do
+    sleep 1
+    if [ -f "$LOG" ]; then
+        vpn_ip=$(python3 -c "
+with open('$LOG', 'rb') as f:
+    t = f.read().decode('utf-16-le', errors='replace')
+lines = t.strip().split('\n')
+has_ready = any('adapter ready' in l for l in lines)
+if has_ready:
+    for l in reversed(lines):
+        if 'Registered as' in l or ('IP:' in l and '0.0.0.0' not in l):
+            import re
+            m = re.search(r'26\.\d+\.\d+\.\d+', l)
+            if m: print(m.group()); break
+" 2>/dev/null)
+        if [ -n "$vpn_ip" ]; then
+            echo "[+] VPN IP: $vpn_ip"
+            break
+        fi
+    fi
+    pgrep -f RvControlSvc >/dev/null || { echo "[-] Service died"; exit 1; }
+done
+
+# 12. Assign VPN IP to TAP device + set up route
+sleep 2
+if [ -n "$vpn_ip" ]; then
+    # Explicitly assign the VPN IP (fallback if netsh_wrapper wasn't invoked)
+    sudo ip addr add "$vpn_ip/8" dev "$TAP_DEV" 2>/dev/null || true
+    sudo ip link set "$TAP_DEV" up 2>/dev/null || true
+    echo "[+] TAP IP: $vpn_ip/8"
+fi
+sudo ip route replace 26.0.0.0/8 dev "$TAP_DEV"
+echo "[+] Route: 26.0.0.0/8 dev $TAP_DEV (on-link)"
+echo ""
+ip addr show "$TAP_DEV" 2>/dev/null | grep -E "inet |state"
+echo ""
+
+# 13. Launch custom GUI (rv_net_enum.exe) instead of original RvRvpnGui.exe
+if [ -f "$CUSTOM_GUI" ]; then
+    echo "[*] Starting custom GUI (rv_net_enum.exe)..."
+    wine "$CUSTOM_GUI" > /tmp/radmin_custom_gui.log 2>&1 &
+    GUI_PID=$!
+    echo "[+] Custom GUI running (pid=$GUI_PID)"
+else
+    echo "[-] Custom GUI not found at $CUSTOM_GUI"
+    echo "    Build it with: i686-w64-mingw32-gcc -o rv_net_enum.exe rv_net_enum.c -mwindows -lkernel32 -luser32 -lgdi32"
+    echo "[*] Service is running headless. Press Ctrl+C to stop."
+    # Wait indefinitely for service
+    while pgrep -f RvControlSvc >/dev/null; do sleep 2; done
+    exit 0
+fi
+
+# 14. Launch filter UI (GTK4)
+if [ -x "$BUILD_DIR/rvpn_filter_ui" ]; then
+    echo "[*] Starting filter UI..."
+    "$BUILD_DIR/rvpn_filter_ui" > /tmp/radmin_filter_ui.log 2>&1 &
+    FILTER_UI_PID=$!
+    echo "[+] Filter UI running (pid=$FILTER_UI_PID)"
+fi
+
+echo "[+] Radmin VPN running with custom GUI. Close the GUI or press Ctrl+C to stop."
+echo ""
+
+wait $GUI_PID || true

--- a/src/adapter_hook.c
+++ b/src/adapter_hook.c
@@ -15,6 +15,8 @@
 #include <windows.h>
 #include <iphlpapi.h>
 #include <string.h>
+#include <stdio.h>
+#include <stdint.h>
 
 #define TAP_DESC     L"radminvpn0"
 #define RADMIN_DESC  L"Famatech Radmin VPN Ethernet Adapter"
@@ -27,12 +29,303 @@ static void dbg(const char *msg)
     HANDLE f = CreateFileA("C:\\radmin_hook_debug.log",
         FILE_APPEND_DATA, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
         OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-    if (f != INVALID_HANDLE_VALUE) {
+    if (f == INVALID_HANDLE_VALUE)
+        return;
+    {
         DWORD w;
         WriteFile(f, msg, strlen(msg), &w, NULL);
         WriteFile(f, "\r\n", 2, &w, NULL);
         CloseHandle(f);
     }
+}
+
+/* ====== Crash capture (vectored exception handler) ======
+ *
+ * RvControlSvc.exe is spawned by rvpn_launcher with bInheritHandles=FALSE, so
+ * its stderr never reaches /tmp/radmin_service.log and Wine's +seh backtrace is
+ * lost. Since this DLL is injected into the service, we install our own handler
+ * that writes a full crash dump (code, faulting address, module+offset,
+ * registers, stack backtrace) straight to a file we control. This is the
+ * authoritative service-side crash capture. */
+
+#define CRASH_LOG "C:\\radmin_crash.log"
+
+static void crashlog(const char *msg)
+{
+    HANDLE f = CreateFileA(CRASH_LOG, FILE_APPEND_DATA,
+        FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+        OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (f == INVALID_HANDLE_VALUE)
+        return;
+    {
+        DWORD w;
+        WriteFile(f, msg, (DWORD)strlen(msg), &w, NULL);
+        CloseHandle(f);
+    }
+}
+
+/* RtlCaptureStackBackTrace lives in ntdll, resolve at runtime */
+static USHORT (WINAPI *p_CaptureStack)(ULONG, ULONG, PVOID *, PULONG) = NULL;
+
+/* Resolve an address to "module.dll+0xoffset" for IDA correlation. */
+static void module_at(void *addr, char *out, size_t outsz)
+{
+    HMODULE hm = NULL;
+    if (GetModuleHandleExA(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+            GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            (LPCSTR)addr, &hm) && hm) {
+        char path[MAX_PATH];
+        if (GetModuleFileNameA(hm, path, MAX_PATH)) {
+            const char *base = strrchr(path, '\\');
+            base = base ? base + 1 : path;
+            snprintf(out, outsz, "%s+0x%lx", base,
+                     (unsigned long)((uintptr_t)addr - (uintptr_t)hm));
+            return;
+        }
+    }
+    snprintf(out, outsz, "%p", addr);
+}
+
+static volatile LONG in_crash = 0;
+
+/* Per-thread TLS slot holding a jmp_buf* while inside the guarded CSetupAdapter
+ * teardown. Native Win32 TLS (not __thread, which mingw lowers to emutls ->
+ * runtime locks/alloc unsafe in an exception handler). TlsGetValue is a
+ * lock-free TEB-array read. */
+static DWORD g_jmp_tls = TLS_OUT_OF_INDEXES;
+static void longjmp_tramp(void);   /* forward decl: redirected-to on recovery */
+
+static LONG CALLBACK crash_handler(PEXCEPTION_POINTERS ep)
+{
+    DWORD code = ep->ExceptionRecord->ExceptionCode;
+
+    /* Only error-severity (0xCxxxxxxx) exceptions; skip C++ EH (0xE06D7363). */
+    if ((code & 0xC0000000) != 0xC0000000)
+        return EXCEPTION_CONTINUE_SEARCH;
+    if (code == 0xE06D7363u)
+        return EXCEPTION_CONTINUE_SEARCH;
+
+    /* Recovery: an access violation happened inside a guarded thread-pool task
+     * (which touched a dangling COM object -- memory queries can't distinguish
+     * reused heap from valid under Wine). The fault can be arbitrarily deep, so
+     * we redirect EIP to a trampoline that longjmp()s back to the task-boundary
+     * setjmp point in hook_dispatch(). That abandons the one faulting task and
+     * lets the worker thread continue. Resume runs on the still-valid stack. */
+    if (code == 0xC0000005u && g_jmp_tls != TLS_OUT_OF_INDEXES &&
+        TlsGetValue(g_jmp_tls)) {
+        crashlog("[task-guard] recovered from fault in worker task "
+                 "(task dropped, service alive)\r\n");
+        ep->ContextRecord->Eip = (DWORD)(ULONG_PTR)&longjmp_tramp;
+        return EXCEPTION_CONTINUE_EXECUTION;
+    }
+
+    /* Re-entrancy guard: a fault inside the handler must not loop. */
+    if (InterlockedExchange(&in_crash, 1) != 0)
+        return EXCEPTION_CONTINUE_SEARCH;
+
+    {
+        char buf[1024];
+        char modbuf[MAX_PATH + 32];
+        CONTEXT *c = ep->ContextRecord;
+        void *pc = ep->ExceptionRecord->ExceptionAddress;
+        SYSTEMTIME st;
+
+        module_at(pc, modbuf, sizeof(modbuf));
+        GetLocalTime(&st);
+        snprintf(buf, sizeof(buf),
+            "\r\n===== CRASH %04d-%02d-%02d %02d:%02d:%02d.%03d =====\r\n"
+            "code=0x%08lx  pc=%p  (%s)\r\n",
+            st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute,
+            st.wSecond, st.wMilliseconds,
+            (unsigned long)code, pc, modbuf);
+        crashlog(buf);
+
+        if (code == 0xC0000005u &&
+            ep->ExceptionRecord->NumberParameters >= 2) {
+            ULONG_PTR kind = ep->ExceptionRecord->ExceptionInformation[0];
+            const char *op = kind == 0 ? "read" : kind == 1 ? "write" : "exec";
+            snprintf(buf, sizeof(buf), "access-violation: %s @ %p\r\n",
+                     op, (void *)ep->ExceptionRecord->ExceptionInformation[1]);
+            crashlog(buf);
+        }
+
+#ifdef __i386__
+        snprintf(buf, sizeof(buf),
+            "EAX=%08lx EBX=%08lx ECX=%08lx EDX=%08lx\r\n"
+            "ESI=%08lx EDI=%08lx EBP=%08lx ESP=%08lx\r\n"
+            "EIP=%08lx EFL=%08lx\r\n",
+            c->Eax, c->Ebx, c->Ecx, c->Edx,
+            c->Esi, c->Edi, c->Ebp, c->Esp,
+            c->Eip, c->EFlags);
+        crashlog(buf);
+#else
+        (void)c;
+#endif
+
+        if (!p_CaptureStack) {
+            HMODULE nt = GetModuleHandleA("ntdll.dll");
+            if (nt)
+                p_CaptureStack = (void *)GetProcAddress(nt,
+                    "RtlCaptureStackBackTrace");
+        }
+        if (p_CaptureStack) {
+            void *frames[48];
+            USHORT i, n = p_CaptureStack(0, 48, frames, NULL);
+            crashlog("backtrace (innermost first):\r\n");
+            for (i = 0; i < n; i++) {
+                module_at(frames[i], modbuf, sizeof(modbuf));
+                snprintf(buf, sizeof(buf), "  #%02u  %p  %s\r\n",
+                         i, frames[i], modbuf);
+                crashlog(buf);
+            }
+        }
+        crashlog("===== END CRASH =====\r\n");
+    }
+
+    in_crash = 0;
+    /* Let Wine/winedbg still see it (AeDebug, default handler). */
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+/* ====== CSetupAdapter teardown guard ======
+ *
+ * The crashing object is a dangling COM INetwork (and other freed members)
+ * cached by ControlSvc::task::CSetupAdapter. When a network is removed/left the
+ * Network List Manager (Wine netprofm) frees the object, but the service keeps
+ * a stale pointer and later calls through its vtable -> 0xc0000005 (observed
+ * pc=0x043304A3, deterministic when joining a busy server with many networks).
+ * The bad pointer is reached from MULTIPLE sites (CSetupAdapter teardown
+ * sub_459B70, INetwork::GetName/SetName sub_45B460, ...) so guarding one
+ * function is whack-a-mole. Memory-validity checks can't help: under Wine the
+ * reused heap reads back committed + executable + MEM_IMAGE.
+ *
+ * Fix: guard at the thread-pool task boundary. sub_4636A0 (RvControlSvc+0x636A0)
+ * is the worker that runs each queued task:
+ *      unsigned __stdcall sub_4636A0(Block) {
+ *        if (Block) { fn=Block[0]; arg=Block[1]; free(Block,8);
+ *                     if (fn) fn(arg);            // __stdcall(arg) -- THE TASK
+ *                     _InterlockedDecrement(&pending); }
+ *        return 0;
+ *      }
+ * We detour it to hook_dispatch, which reimplements it but runs fn(arg) under
+ * __builtin_setjmp. ANY access violation anywhere in the task is caught by the
+ * crash handler (which redirects EIP to longjmp_tramp -> longjmp back here),
+ * the whole task is abandoned, the pending counter is still decremented, and
+ * the worker thread continues. One faulting task is dropped; the service lives.
+ * The setjmp scope == the entire task, so recovery never unwinds to a stale
+ * frame. Installed from DllMain before any task runs. */
+
+#define DISPATCH_RVA 0x636A0        /* sub_4636A0 worker entry          */
+#define FREE_RVA     0xC9001        /* sub_4C9001 = operator delete(p,n) */
+#define COUNTER_RVA  0x13F1D8       /* dword_53F1D8 pending-task count   */
+
+static BYTE *g_rvbase = NULL;       /* RvControlSvc.exe load base */
+
+/* The crash handler redirects EIP here on a recoverable fault. Runs on the
+ * faulting thread's still-valid stack; longjmp restores esp/ebp/eip to the
+ * active hook_dispatch() setjmp point (the task boundary). */
+static void longjmp_tramp(void)
+{
+    if (g_jmp_tls != TLS_OUT_OF_INDEXES) {
+        void **e = (void **)TlsGetValue(g_jmp_tls);
+        if (e)
+            __builtin_longjmp(e, 1);            /* raw fp/sp/pc restore */
+    }
+    for (;;)                                     /* TLS broken: contain, don't loop wild */
+        Sleep(1000);
+}
+
+/* Reimplementation of sub_4636A0 (__stdcall, retn 4) with the task call run
+ * under fault recovery. */
+static unsigned __stdcall hook_dispatch(void **Block)
+{
+    if (Block) {
+        void *fn  = Block[0];
+        void *arg = Block[1];
+        /* free the work block: __cdecl operator delete(ptr, 8) */
+        ((void (__cdecl *)(void *, unsigned))(g_rvbase + FREE_RVA))(Block, 8);
+        if (fn) {
+            void *env[5];                        /* __builtin_setjmp buffer */
+            void **prev;
+            if (g_jmp_tls != TLS_OUT_OF_INDEXES) {
+                prev = (void **)TlsGetValue(g_jmp_tls);
+                TlsSetValue(g_jmp_tls, env);
+                if (__builtin_setjmp(env) == 0)
+                    ((void (__stdcall *)(void *))fn)(arg);  /* may fault */
+                TlsSetValue(g_jmp_tls, prev);
+            } else {
+                ((void (__stdcall *)(void *))fn)(arg);
+            }
+        }
+        /* Always decrement, even for an abandoned task, so the pool accounting
+         * doesn't leak a phantom pending task. */
+        _InterlockedDecrement((long *)(g_rvbase + COUNTER_RVA));
+    }
+    return 0;
+}
+
+#define GETINETWORK_RVA 0x5BA70     /* sub_45BA70 rvpn::GetINetwork getter */
+
+static void install_release_guard(void)
+{
+    /* sub_4636A0 prologue: push ebp; mov ebp,esp; push -1 (55 8B EC 6A FF). */
+    static const BYTE expect[5] = { 0x55, 0x8B, 0xEC, 0x6A, 0xFF };
+    HMODULE base = GetModuleHandleA(NULL);
+    BYTE *t;
+    DWORD old;
+
+    if (!base) {
+        dbg("task-guard: no module base");
+        return;
+    }
+    g_rvbase = (BYTE *)base;
+
+    /* PRIMARY FIX -- neutralise rvpn::GetINetwork (sub_45BA70, +0x5BA70). It
+     * caches a Wine netprofm INetwork at CSetupAdapter+0x1D4; Wine frees that
+     * object on network changes ("netprofm: no support for detecting network
+     * changes"), so every later GetName/SetName/release through the stale
+     * pointer faults (0xc0000005 @ 0x043304A3) when joining a busy server. The
+     * function already has a handled "failed -> return 0" path, so stub it to
+     * always return 0: the service skips the network naming (a no-op under
+     * Wine's stub netprofm anyway) and the setup task completes normally, adapter
+     * intact. __thiscall, bool in AL, no stack args -> `xor al,al; ret`. */
+    {
+        static const BYTE gi_expect[3] = { 0x56, 0x57, 0x8B };  /* push esi;push edi;mov edi,ecx */
+        BYTE *g = (BYTE *)base + GETINETWORK_RVA;
+        DWORD go;
+        if (memcmp(g, gi_expect, sizeof(gi_expect)) != 0) {
+            dbg("GetINetwork stub: prologue mismatch, skip");
+        } else if (!VirtualProtect(g, 3, PAGE_EXECUTE_READWRITE, &go)) {
+            dbg("GetINetwork stub: VirtualProtect failed");
+        } else {
+            g[0] = 0x30; g[1] = 0xC0;            /* xor al, al */
+            g[2] = 0xC3;                         /* ret        */
+            VirtualProtect(g, 3, go, &go);
+            FlushInstructionCache(GetCurrentProcess(), g, 3);
+            dbg("GetINetwork stubbed at RvControlSvc+0x5BA70 (always return 0)");
+        }
+    }
+
+    /* SAFETY NET -- task-level fault guard (see hook_dispatch). */
+    t = (BYTE *)base + DISPATCH_RVA;
+    if (memcmp(t, expect, sizeof(expect)) != 0) {
+        dbg("task-guard: prologue mismatch -- wrong RvControlSvc, skip");
+        return;
+    }
+    if (!VirtualProtect(t, 6, PAGE_EXECUTE_READWRITE, &old)) {
+        dbg("task-guard: VirtualProtect failed");
+        return;
+    }
+    /* Absolute `push hook; ret` (range-independent under LARGE_ADDRESS_AWARE).
+     * Overwrites 6 bytes; the original body is never executed -- hook_dispatch
+     * reimplements it. */
+    t[0] = 0x68;
+    *(DWORD *)(t + 1) = (DWORD)(ULONG_PTR)hook_dispatch;
+    t[5] = 0xC3;
+    VirtualProtect(t, 6, old, &old);
+    FlushInstructionCache(GetCurrentProcess(), t, 6);
+    dbg("task-guard installed at RvControlSvc+0x636A0");
 }
 
 /* ====== GetAdaptersAddresses hook ====== */
@@ -112,9 +405,14 @@ static void patch_iat(HMODULE mod)
                 if (strcmp(by_name->Name, "GetAdaptersAddresses") == 0) {
                     real_GetAdaptersAddresses = (void *)thunk->u1.Function;
                     DWORD old;
-                    VirtualProtect(&thunk->u1.Function, sizeof(DWORD_PTR), PAGE_READWRITE, &old);
+                    if (!VirtualProtect(&thunk->u1.Function, sizeof(DWORD_PTR), PAGE_READWRITE, &old)) {
+                        dbg("VirtualProtect failed for GetAdaptersAddresses");
+                        continue;
+                    }
                     thunk->u1.Function = (DWORD_PTR)hook_GetAdaptersAddresses;
-                    VirtualProtect(&thunk->u1.Function, sizeof(DWORD_PTR), old, &old);
+                    if (!VirtualProtect(&thunk->u1.Function, sizeof(DWORD_PTR), old, &old)) {
+                        dbg("VirtualProtect restore failed for GetAdaptersAddresses");
+                    }
                     dbg("hooked GetAdaptersAddresses");
                 }
             }
@@ -130,9 +428,14 @@ static void patch_iat(HMODULE mod)
                 if (strcmp(by_name->Name, "RegSetKeySecurity") == 0) {
                     real_RegSetKeySecurity = (void *)thunk->u1.Function;
                     DWORD old;
-                    VirtualProtect(&thunk->u1.Function, sizeof(DWORD_PTR), PAGE_READWRITE, &old);
+                    if (!VirtualProtect(&thunk->u1.Function, sizeof(DWORD_PTR), PAGE_READWRITE, &old)) {
+                        dbg("VirtualProtect failed for RegSetKeySecurity");
+                        continue;
+                    }
                     thunk->u1.Function = (DWORD_PTR)hook_RegSetKeySecurity;
-                    VirtualProtect(&thunk->u1.Function, sizeof(DWORD_PTR), old, &old);
+                    if (!VirtualProtect(&thunk->u1.Function, sizeof(DWORD_PTR), old, &old)) {
+                        dbg("VirtualProtect restore failed for RegSetKeySecurity");
+                    }
                     dbg("hooked RegSetKeySecurity");
                 }
             }
@@ -151,6 +454,17 @@ BOOL WINAPI DllMain(HINSTANCE inst, DWORD reason, LPVOID reserved)
     (void)inst; (void)reserved;
     if (reason == DLL_PROCESS_ATTACH) {
         dbg("adapter_hook.dll loaded");
+
+        /* Install crash capture first so a fault anywhere in the service
+         * (incl. the packet path) gets dumped to C:\radmin_crash.log. */
+        AddVectoredExceptionHandler(1, crash_handler);
+        dbg("crash handler installed");
+
+        /* Guard CSetupAdapter's dangling-INetwork release (join-with-many-
+         * networks crash). Allocate the recovery TLS slot before arming the
+         * detour. Safe no-op on a non-matching binary. */
+        g_jmp_tls = TlsAlloc();
+        install_release_guard();
 
         HMODULE exe = GetModuleHandle(NULL);
         if (!exe) {

--- a/src/netsh_wrapper.c
+++ b/src/netsh_wrapper.c
@@ -13,10 +13,14 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
+#define NETSH_CMD_DELAY_MS    1500
+#define NETSH_ENABLE_DELAY_MS  500
+
 /* Convert wide string arg to narrow */
 static char *to_narrow(const WCHAR *w) {
     int len = WideCharToMultiByte(CP_UTF8, 0, w, -1, NULL, 0, NULL, NULL);
     char *buf = malloc(len + 1);
+    if (!buf) return NULL;
     WideCharToMultiByte(CP_UTF8, 0, w, -1, buf, len + 1, NULL, NULL);
     return buf;
 }
@@ -45,6 +49,20 @@ int wmain(int argc, WCHAR *argv[])
     /* Reconstruct command line */
     for (i = 1; i < argc; i++) {
         char *a = to_narrow(argv[i]);
+        if (!a) continue;
+        
+        size_t current_len = strlen(cmdline);
+        size_t arg_len = strlen(a);
+        size_t space_needed = arg_len + 1; /* +1 for space */
+        
+        if (i > 1) space_needed += 1; /* Account for the space we'll add */
+        
+        if (current_len + space_needed >= sizeof(cmdline)) {
+            fprintf(stderr, "netsh_wrapper: command line too long\n");
+            free(a);
+            break;
+        }
+        
         if (i > 1) strcat(cmdline, " ");
         strcat(cmdline, a);
         free(a);
@@ -58,15 +76,20 @@ int wmain(int argc, WCHAR *argv[])
     /* Also: "interface set interface XXX ENABLE" */
     /* Also: "interface ipv6 add address interface=XXX address=YYY" */
 
-    if (strstr(cmdline, "interface") && strstr(cmdline, "add address")) {
+    if (strstr(cmdline, "interface") &&
+        (strstr(cmdline, "add address") || strstr(cmdline, "set address"))) {
         char *p;
-        /* Extract addr= */
-        p = strstr(cmdline, "addr=");
-        if (!p) p = strstr(cmdline, "address=");
-        if (p) {
-            p = strchr(p, '=') + 1;
-            addr = p;
-            char *end = strchr(p, ' ');
+        /* Extract addr= or address= (use address= first for "set address") */
+        if (strstr(cmdline, "set address")) {
+            p = strstr(cmdline, "address=");
+            if (p) { p = strchr(p, '=') + 1; addr = p; }
+        } else {
+            p = strstr(cmdline, "addr=");
+            if (!p) p = strstr(cmdline, "address=");
+            if (p) { p = strchr(p, '=') + 1; addr = p; }
+        }
+        if (addr) {
+            char *end = strchr(addr, ' ');
             if (end) *end = '\0';
         }
         /* Extract mask= */
@@ -103,7 +126,7 @@ int wmain(int argc, WCHAR *argv[])
                                "ip link set radminvpn0 up 2>/dev/null\n",
                             addr, cidr);
                     fclose(f);
-                    Sleep(1500);
+                    Sleep(NETSH_CMD_DELAY_MS);
                 }
             }
             return 0;
@@ -112,7 +135,7 @@ int wmain(int argc, WCHAR *argv[])
 
     if (strstr(cmdline, "interface set interface") && strstr(cmdline, "ENABLE")) {
         FILE *f = _wfopen(L"Z:\\tmp\\radmin_netsh_cmd", L"a");
-        if (f) { fprintf(f, "ip link set radminvpn0 up\n"); fclose(f); Sleep(500); }
+        if (f) { fprintf(f, "ip link set radminvpn0 up\n"); fclose(f); Sleep(NETSH_ENABLE_DELAY_MS); }
         return 0;
     }
 
@@ -129,7 +152,7 @@ int wmain(int argc, WCHAR *argv[])
                 fprintf(f, "ip -6 addr add %s/128 dev radminvpn0 2>/dev/null\n", p);
                 fclose(f);
                 spy_log("ipv6 add: %s", p);
-                Sleep(1500);
+                Sleep(NETSH_CMD_DELAY_MS);
             }
         }
         return 0;
@@ -137,7 +160,7 @@ int wmain(int argc, WCHAR *argv[])
 
     if (strstr(cmdline, "interface ip delete") && strstr(cmdline, "address")) {
         FILE *f = _wfopen(L"Z:\\tmp\\radmin_netsh_cmd", L"a");
-        if (f) { fprintf(f, "ip addr flush dev radminvpn0\n"); fclose(f); Sleep(500); }
+        if (f) { fprintf(f, "ip addr flush dev radminvpn0\n"); fclose(f); Sleep(NETSH_ENABLE_DELAY_MS); }
         return 0;
     }
 

--- a/src/rvpn_filter_ui.c
+++ b/src/rvpn_filter_ui.c
@@ -1,0 +1,610 @@
+/*
+ * rvpn_filter_ui — GTK4 interface for managing Radmin VPN packet filter rules.
+ *
+ * Escreve /tmp/rvpn_filters.json a cada alteração (adicionar/remover/alternar).
+ * tap_bridge verifica este arquivo e aplica os filtros em ~1s.
+ *
+ * Compilação: gcc -Wall -O2 -o cc_filter_ui rvpn_filter_ui.c $(pkg-config --cflags --libs gtk4)
+ */
+
+#include <gtk/gtk.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define FILTER_PATH "/tmp/rvpn_filters.json"
+#define MAX_ENTRIES 256
+#define INTERFACE_NAME "radminvpn0"
+
+/* ── Estado do aplicativo ── */
+
+typedef struct {
+    char *entries[MAX_ENTRIES];
+    int   count;
+    int   enabled;
+} filter_section_t;
+
+typedef struct {
+    filter_section_t block_ips;
+    filter_section_t block_macs;
+    filter_section_t block_broadcast;
+    GtkListBox      *ip_list;
+    GtkListBox      *mac_list;
+    GtkListBox      *bcast_list;
+    GtkSwitch       *ip_switch;
+    GtkSwitch       *mac_switch;
+    GtkSwitch       *bcast_switch;
+    GtkEntry        *ip_entry;
+    GtkEntry        *mac_entry;
+    GtkEntry        *bcast_entry;
+} app_state_t;
+
+static app_state_t app;
+
+/* ── Gerenciamento de regras de firewall ── */
+
+static void run_command(const char *cmd)
+{
+    fprintf(stderr, "cc_filter_ui: exec: %s\n", cmd);
+    (void)system(cmd);
+}
+
+/* Limpar todas as regras de filtro rvpn */
+static void clear_all_rules(void)
+{
+    /* Remove regras iptables com comentário 'rvpn-filter' */
+    run_command("sudo iptables -L INPUT -n --line-numbers | grep 'rvpn-filter' | awk '{print $1}' | sort -rn | xargs -r -I {} sudo iptables -D INPUT {} 2>/dev/null");
+    run_command("sudo iptables -L OUTPUT -n --line-numbers | grep 'rvpn-filter' | awk '{print $1}' | sort -rn | xargs -r -I {} sudo iptables -D OUTPUT {} 2>/dev/null");
+    run_command("sudo iptables -L FORWARD -n --line-numbers | grep 'rvpn-filter' | awk '{print $1}' | sort -rn | xargs -r -I {} sudo iptables -D FORWARD {} 2>/dev/null");
+
+    /* Remove regras ebtables para filtragem de MAC */
+    run_command("sudo ebtables -L INPUT -n --line-numbers 2>/dev/null | grep 'rvpn-filter' | awk '{print $1}' | sort -rn | xargs -r -I {} sudo ebtables -D INPUT {} 2>/dev/null");
+    run_command("sudo ebtables -L OUTPUT -n --line-numbers 2>/dev/null | grep 'rvpn-filter' | awk '{print $1}' | sort -rn | xargs -r -I {} sudo ebtables -D OUTPUT {} 2>/dev/null");
+}
+
+/* Aplicar regras de bloqueio de IP */
+static void apply_ip_rules(void)
+{
+    if (!app.block_ips.enabled || app.block_ips.count == 0) {
+        return;
+    }
+    
+    for (int i = 0; i < app.block_ips.count; i++) {
+        const char *ip = app.block_ips.entries[i];
+        char cmd[512];
+        int len;
+        
+        /* iptables: bloqueia ambas as direções em radminvpn0 */
+        len = snprintf(cmd, sizeof(cmd), "sudo iptables -I INPUT -i %s -s %s -j DROP -m comment --comment 'rvpn-filter'", INTERFACE_NAME, ip);
+        if (len < 0 || (size_t)len >= sizeof(cmd)) {
+            fprintf(stderr, "cc_filter_ui: command too long for IP %s\n", ip);
+            continue;
+        }
+        run_command(cmd);
+        
+        len = snprintf(cmd, sizeof(cmd), "sudo iptables -I OUTPUT -o %s -d %s -j DROP -m comment --comment 'rvpn-filter'", INTERFACE_NAME, ip);
+        if (len < 0 || (size_t)len >= sizeof(cmd)) {
+            fprintf(stderr, "cc_filter_ui: command too long for IP %s\n", ip);
+            continue;
+        }
+        run_command(cmd);
+        
+        len = snprintf(cmd, sizeof(cmd), "sudo iptables -I FORWARD -i %s -s %s -j DROP -m comment --comment 'rvpn-filter'", INTERFACE_NAME, ip);
+        if (len < 0 || (size_t)len >= sizeof(cmd)) {
+            fprintf(stderr, "cc_filter_ui: command too long for IP %s\n", ip);
+            continue;
+        }
+        run_command(cmd);
+        
+        len = snprintf(cmd, sizeof(cmd), "sudo iptables -I FORWARD -o %s -d %s -j DROP -m comment --comment 'rvpn-filter'", INTERFACE_NAME, ip);
+        if (len < 0 || (size_t)len >= sizeof(cmd)) {
+            fprintf(stderr, "cc_filter_ui: command too long for IP %s\n", ip);
+            continue;
+        }
+        run_command(cmd);
+    }
+}
+
+/* Aplicar regras de bloqueio de MAC */
+static void apply_mac_rules(void)
+{
+    if (!app.block_macs.enabled || app.block_macs.count == 0) {
+        return;
+    }
+    
+    /* Filtragem de MAC requer ebtables ou iptables com módulo mac */
+    /* Tenta ebtables primeiro, recorre ao módulo mac do iptables */
+    if (system("which ebtables > /dev/null 2>&1") == 0) {
+        for (int i = 0; i < app.block_macs.count; i++) {
+            const char *mac = app.block_macs.entries[i];
+            char cmd[512];
+            int len;
+            
+            /* ebtables: bloqueia ambas as direções em radminvpn0 */
+            len = snprintf(cmd, sizeof(cmd), "sudo ebtables -I INPUT -i %s -s %s -j DROP --comment 'rvpn-filter'", INTERFACE_NAME, mac);
+            if (len < 0 || (size_t)len >= sizeof(cmd)) {
+                fprintf(stderr, "cc_filter_ui: command too long for MAC %s\n", mac);
+                continue;
+            }
+            run_command(cmd);
+            
+            len = snprintf(cmd, sizeof(cmd), "sudo ebtables -I OUTPUT -o %s -d %s -j DROP --comment 'rvpn-filter'", INTERFACE_NAME, mac);
+            if (len < 0 || (size_t)len >= sizeof(cmd)) {
+                fprintf(stderr, "cc_filter_ui: command too long for MAC %s\n", mac);
+                continue;
+            }
+            run_command(cmd);
+        }
+    } else {
+        /* Recurso ao iptables com módulo mac (menos preciso, funciona apenas na camada IP) */
+        fprintf(stderr, "cc_filter_ui: ebtables indisponível, filtragem de MAC limitada\n");
+        for (int i = 0; i < app.block_macs.count; i++) {
+            const char *mac = app.block_macs.entries[i];
+            char cmd[512];
+            int len;
+            
+            /* Módulo mac do iptables funciona apenas em pacotes de entrada */
+            len = snprintf(cmd, sizeof(cmd), "sudo iptables -I INPUT -i %s -m mac --mac-source %s -j DROP -m comment --comment 'rvpn-filter'", INTERFACE_NAME, mac);
+            if (len < 0 || (size_t)len >= sizeof(cmd)) {
+                fprintf(stderr, "cc_filter_ui: command too long for MAC %s\n", mac);
+                continue;
+            }
+            run_command(cmd);
+        }
+    }
+}
+
+/* Aplicar regras de bloqueio de broadcast (UDP:4445) */
+static void apply_broadcast_rules(void)
+{
+    if (!app.block_broadcast.enabled || app.block_broadcast.count == 0) {
+        return;
+    }
+    
+    for (int i = 0; i < app.block_broadcast.count; i++) {
+        const char *ip = app.block_broadcast.entries[i];
+        char cmd[512];
+        int len;
+        
+        /* iptables: bloqueia porta UDP 4445 de/para IP específico em radminvpn0 */
+        len = snprintf(cmd, sizeof(cmd), "sudo iptables -I INPUT -i %s -s %s -p udp --dport 4445 -j DROP -m comment --comment 'rvpn-filter'", INTERFACE_NAME, ip);
+        if (len < 0 || (size_t)len >= sizeof(cmd)) {
+            fprintf(stderr, "cc_filter_ui: command too long for broadcast IP %s\n", ip);
+            continue;
+        }
+        run_command(cmd);
+        
+        len = snprintf(cmd, sizeof(cmd), "sudo iptables -I INPUT -i %s -d %s -p udp --sport 4445 -j DROP -m comment --comment 'rvpn-filter'", INTERFACE_NAME, ip);
+        if (len < 0 || (size_t)len >= sizeof(cmd)) {
+            fprintf(stderr, "cc_filter_ui: command too long for broadcast IP %s\n", ip);
+            continue;
+        }
+        run_command(cmd);
+        
+        len = snprintf(cmd, sizeof(cmd), "sudo iptables -I OUTPUT -o %s -d %s -p udp --dport 4445 -j DROP -m comment --comment 'rvpn-filter'", INTERFACE_NAME, ip);
+        if (len < 0 || (size_t)len >= sizeof(cmd)) {
+            fprintf(stderr, "cc_filter_ui: command too long for broadcast IP %s\n", ip);
+            continue;
+        }
+        run_command(cmd);
+        
+        len = snprintf(cmd, sizeof(cmd), "sudo iptables -I OUTPUT -o %s -s %s -p udp --sport 4445 -j DROP -m comment --comment 'rvpn-filter'", INTERFACE_NAME, ip);
+        if (len < 0 || (size_t)len >= sizeof(cmd)) {
+            fprintf(stderr, "cc_filter_ui: command too long for broadcast IP %s\n", ip);
+            continue;
+        }
+        run_command(cmd);
+        
+        len = snprintf(cmd, sizeof(cmd), "sudo iptables -I FORWARD -i %s -s %s -p udp --dport 4445 -j DROP -m comment --comment 'rvpn-filter'", INTERFACE_NAME, ip);
+        if (len < 0 || (size_t)len >= sizeof(cmd)) {
+            fprintf(stderr, "cc_filter_ui: command too long for broadcast IP %s\n", ip);
+            continue;
+        }
+        run_command(cmd);
+        
+        len = snprintf(cmd, sizeof(cmd), "sudo iptables -I FORWARD -o %s -d %s -p udp --dport 4445 -j DROP -m comment --comment 'rvpn-filter'", INTERFACE_NAME, ip);
+        if (len < 0 || (size_t)len >= sizeof(cmd)) {
+            fprintf(stderr, "cc_filter_ui: command too long for broadcast IP %s\n", ip);
+            continue;
+        }
+        run_command(cmd);
+    }
+}
+
+/* Aplicar todas as regras de firewall */
+static void apply_firewall_rules(void)
+{
+    clear_all_rules();
+    apply_ip_rules();
+    apply_mac_rules();
+    apply_broadcast_rules();
+}
+
+/* ── Entrada/Saída JSON ── */
+
+static void write_json(void)
+{
+    FILE *f = fopen(FILTER_PATH ".tmp", "w");
+    if (!f) { perror("write_json"); return; }
+
+    fprintf(f, "{\n");
+    fprintf(f, "  \"block_ips_enabled\": %s,\n", app.block_ips.enabled ? "true" : "false");
+    fprintf(f, "  \"blocked_ips\": [");
+    for (int i = 0; i < app.block_ips.count; i++) {
+        if (i > 0) fprintf(f, ", ");
+        fprintf(f, "\"%s\"", app.block_ips.entries[i]);
+    }
+    fprintf(f, "],\n");
+
+    fprintf(f, "  \"block_macs_enabled\": %s,\n", app.block_macs.enabled ? "true" : "false");
+    fprintf(f, "  \"blocked_macs\": [");
+    for (int i = 0; i < app.block_macs.count; i++) {
+        if (i > 0) fprintf(f, ", ");
+        fprintf(f, "\"%s\"", app.block_macs.entries[i]);
+    }
+    fprintf(f, "],\n");
+
+    fprintf(f, "  \"block_broadcast_enabled\": %s,\n", app.block_broadcast.enabled ? "true" : "false");
+    fprintf(f, "  \"broadcast_block_ips\": [");
+    for (int i = 0; i < app.block_broadcast.count; i++) {
+        if (i > 0) fprintf(f, ", ");
+        fprintf(f, "\"%s\"", app.block_broadcast.entries[i]);
+    }
+    fprintf(f, "]\n");
+
+    fprintf(f, "}\n");
+    fclose(f);
+    rename(FILTER_PATH ".tmp", FILTER_PATH);
+    
+    /* Aplica regras de firewall após escrever a configuração */
+    apply_firewall_rules();
+}
+
+/* Analisador JSON mínimo (mesma abordagem que tap_bridge) */
+static const char *json_find_key(const char *json, const char *key)
+{
+    char needle[64];
+    snprintf(needle, sizeof(needle), "\"%s\"", key);
+    const char *p = strstr(json, needle);
+    if (!p) return NULL;
+    p += strlen(needle);
+    while (*p == ' ' || *p == '\t' || *p == ':' || *p == '\n' || *p == '\r') p++;
+    return p;
+}
+
+static int json_bool(const char *json, const char *key, int defval)
+{
+    const char *p = json_find_key(json, key);
+    if (!p) return defval;
+    if (strncmp(p, "true", 4) == 0) return 1;
+    if (strncmp(p, "false", 5) == 0) return 0;
+    return defval;
+}
+
+static int json_str_array(const char *json, const char *key,
+                          char **out, int max_out)
+{
+    const char *p = json_find_key(json, key);
+    if (!p || *p != '[') return 0;
+    p++;
+    int count = 0;
+    while (count < max_out) {
+        while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r' || *p == ',') p++;
+        if (*p == ']' || *p == '\0') break;
+        if (*p != '"') { p++; continue; }
+        p++;
+        const char *start = p;
+        while (*p && *p != '"') p++;
+        int len = (int)(p - start);
+        out[count] = g_strndup(start, len);
+        if (*p == '"') p++;
+        count++;
+    }
+    return count;
+}
+
+static void load_json(void)
+{
+    FILE *f = fopen(FILTER_PATH, "r");
+    if (!f) return;
+    fseek(f, 0, SEEK_END);
+    long sz = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (sz <= 0 || sz > 65536) { fclose(f); return; }
+    char *buf = malloc((size_t)sz + 1);
+    if (!buf) { fclose(f); return; }
+    size_t rd = fread(buf, 1, (size_t)sz, f);
+    fclose(f);
+    buf[rd] = '\0';
+
+    app.block_ips.enabled       = json_bool(buf, "block_ips_enabled", 0);
+    app.block_macs.enabled      = json_bool(buf, "block_macs_enabled", 0);
+    app.block_broadcast.enabled = json_bool(buf, "block_broadcast_enabled", 0);
+
+    app.block_ips.count       = json_str_array(buf, "blocked_ips",
+                                    app.block_ips.entries, MAX_ENTRIES);
+    app.block_macs.count      = json_str_array(buf, "blocked_macs",
+                                    app.block_macs.entries, MAX_ENTRIES);
+    app.block_broadcast.count = json_str_array(buf, "broadcast_block_ips",
+                                    app.block_broadcast.entries, MAX_ENTRIES);
+    free(buf);
+}
+
+/* ── Gerenciamento de listas ── */
+
+static void free_section(filter_section_t *s)
+{
+    for (int i = 0; i < s->count; i++) {
+        g_free(s->entries[i]);
+        s->entries[i] = NULL;
+    }
+    s->count = 0;
+}
+
+static int add_entry(filter_section_t *s, const char *val)
+{
+    if (s->count >= MAX_ENTRIES) return 0;
+    /* evitar duplicatas */
+    for (int i = 0; i < s->count; i++) {
+        if (strcmp(s->entries[i], val) == 0) return 0;
+    }
+    s->entries[s->count++] = g_strdup(val);
+    return 1;
+}
+
+static void remove_entry(filter_section_t *s, int idx)
+{
+    if (idx < 0 || idx >= s->count) return;
+    g_free(s->entries[idx]);
+    for (int i = idx; i < s->count - 1; i++)
+        s->entries[i] = s->entries[i + 1];
+    s->entries[--s->count] = NULL;
+}
+
+/* ── Auxiliares de interface ── */
+
+typedef struct {
+    filter_section_t *section;
+    int               index;
+    GtkListBox       *listbox;
+} row_data_t;
+
+/* Declaração antecipada */
+static void refresh_list(GtkListBox *lb, filter_section_t *s);
+
+static void on_remove_row(GtkButton *btn, gpointer user_data)
+{
+    row_data_t *rd = user_data;
+    int idx = rd->index;
+    GtkListBox *lb = rd->listbox;
+    filter_section_t *s = rd->section;
+    remove_entry(s, idx);
+    write_json();
+    refresh_list(lb, s);
+}
+
+static void refresh_list(GtkListBox *lb, filter_section_t *s)
+{
+    /* Remove todos os filhos */
+    GtkWidget *child = gtk_widget_get_first_child(GTK_WIDGET(lb));
+    while (child) {
+        GtkWidget *next = gtk_widget_get_next_sibling(child);
+        gtk_list_box_remove(lb, child);
+        child = next;
+    }
+
+    for (int i = 0; i < s->count; i++) {
+        GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
+        gtk_widget_set_margin_start(row, 8);
+        gtk_widget_set_margin_end(row, 8);
+        gtk_widget_set_margin_top(row, 4);
+        gtk_widget_set_margin_bottom(row, 4);
+
+        GtkWidget *label = gtk_label_new(s->entries[i]);
+        gtk_widget_set_hexpand(label, TRUE);
+        gtk_widget_set_halign(label, GTK_ALIGN_START);
+        gtk_box_append(GTK_BOX(row), label);
+
+        GtkWidget *btn = gtk_button_new_with_label("✕");
+        gtk_widget_add_css_class(btn, "destructive-action");
+        gtk_button_set_has_frame(GTK_BUTTON(btn), FALSE);
+
+        row_data_t *rd = g_new0(row_data_t, 1);
+        rd->section = s;
+        rd->index = i;
+        rd->listbox = lb;
+        g_signal_connect_data(btn, "clicked", G_CALLBACK(on_remove_row),
+                              rd, (GClosureNotify)g_free, 0);
+
+        gtk_box_append(GTK_BOX(row), btn);
+        gtk_list_box_append(lb, row);
+    }
+}
+
+static void on_add_clicked(GtkButton *btn, gpointer user_data)
+{
+    GtkEntry *entry;
+    filter_section_t *section;
+    GtkListBox *listbox;
+
+    if (user_data == &app.block_ips) {
+        entry = app.ip_entry;
+        section = &app.block_ips;
+        listbox = app.ip_list;
+    } else if (user_data == &app.block_macs) {
+        entry = app.mac_entry;
+        section = &app.block_macs;
+        listbox = app.mac_list;
+    } else {
+        entry = app.bcast_entry;
+        section = &app.block_broadcast;
+        listbox = app.bcast_list;
+    }
+
+    const char *text = gtk_editable_get_text(GTK_EDITABLE(entry));
+    if (!text || !*text) return;
+
+    if (add_entry(section, text)) {
+        gtk_editable_set_text(GTK_EDITABLE(entry), "");
+        write_json();
+        refresh_list(listbox, section);
+    }
+}
+
+static void on_entry_activate(GtkEntry *entry, gpointer user_data)
+{
+    on_add_clicked(NULL, user_data);
+}
+
+static void on_switch_toggled(GtkSwitch *sw, GParamSpec *pspec, gpointer user_data)
+{
+    filter_section_t *s = user_data;
+    s->enabled = gtk_switch_get_active(sw);
+    write_json();
+}
+
+/* ── Constrói um cartão de seção de filtro ── */
+
+static GtkWidget *make_section(const char *title,
+                               const char *placeholder,
+                               filter_section_t *section,
+                               GtkSwitch **out_switch,
+                               GtkEntry **out_entry,
+                               GtkListBox **out_list)
+{
+    GtkWidget *card = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
+    gtk_widget_set_margin_start(card, 12);
+    gtk_widget_set_margin_end(card, 12);
+    gtk_widget_set_margin_top(card, 12);
+    gtk_widget_set_margin_bottom(card, 12);
+
+    /* Linha de título com interruptor */
+    GtkWidget *title_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    GtkWidget *lbl = gtk_label_new(title);
+    gtk_widget_set_hexpand(lbl, TRUE);
+    gtk_widget_set_halign(lbl, GTK_ALIGN_START);
+    g_object_set(lbl, "margin-start", 0, NULL);
+    PangoAttrList *attrs = pango_attr_list_new();
+    pango_attr_list_insert(attrs, pango_attr_weight_new(PANGO_WEIGHT_BOLD));
+    pango_attr_list_insert(attrs, pango_attr_scale_new(1.1));
+    gtk_label_set_attributes(GTK_LABEL(lbl), attrs);
+    pango_attr_list_unref(attrs);
+    gtk_box_append(GTK_BOX(title_row), lbl);
+
+    GtkSwitch *sw = GTK_SWITCH(gtk_switch_new());
+    gtk_switch_set_active(sw, section->enabled);
+    g_signal_connect(sw, "notify::active", G_CALLBACK(on_switch_toggled), section);
+    gtk_box_append(GTK_BOX(title_row), GTK_WIDGET(sw));
+    gtk_box_append(GTK_BOX(card), title_row);
+
+    /* Linha de entrada */
+    GtkWidget *entry_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 4);
+    GtkEntry *ent = GTK_ENTRY(gtk_entry_new());
+    gtk_entry_set_placeholder_text(ent, placeholder);
+    gtk_widget_set_hexpand(GTK_WIDGET(ent), TRUE);
+    g_signal_connect(ent, "activate", G_CALLBACK(on_entry_activate), section);
+    gtk_box_append(GTK_BOX(entry_row), GTK_WIDGET(ent));
+
+    GtkWidget *add_btn = gtk_button_new_with_label("Adicionar");
+    g_signal_connect(add_btn, "clicked", G_CALLBACK(on_add_clicked), section);
+    gtk_box_append(GTK_BOX(entry_row), add_btn);
+    gtk_box_append(GTK_BOX(card), entry_row);
+
+    /* Lista */
+    GtkListBox *lb = GTK_LIST_BOX(gtk_list_box_new());
+    gtk_widget_add_css_class(GTK_WIDGET(lb), "rich-list");
+    gtk_list_box_set_selection_mode(lb, GTK_SELECTION_NONE);
+    gtk_box_append(GTK_BOX(card), GTK_WIDGET(lb));
+
+    *out_switch = sw;
+    *out_entry = ent;
+    *out_list = lb;
+
+    /* Preencher */
+    refresh_list(lb, section);
+
+    return card;
+}
+
+/* ── Principal ── */
+
+static void on_activate(GtkApplication *gtk_app, gpointer user_data)
+{
+    (void)user_data;
+
+    /* Carrega configuração existente */
+    load_json();
+
+    GtkWidget *window = gtk_application_window_new(gtk_app);
+    gtk_window_set_title(GTK_WINDOW(window), "Radmin VPN — Packet Filters");
+    gtk_window_set_default_size(GTK_WINDOW(window), 480, 520);
+
+    /* Contêiner principal */
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_widget_set_vexpand(scrolled, TRUE);
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+
+    GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 16);
+    gtk_widget_set_margin_start(vbox, 8);
+    gtk_widget_set_margin_end(vbox, 8);
+    gtk_widget_set_margin_top(vbox, 8);
+    gtk_widget_set_margin_bottom(vbox, 8);
+
+    /* Seção 1: Bloquear IPs */
+    GtkWidget *ip_card = make_section("Bloquear Endereços IP",
+                                      "ex: 26.1.2.3",
+                                      &app.block_ips,
+                                      &app.ip_switch, &app.ip_entry, &app.ip_list);
+    gtk_box_append(GTK_BOX(vbox), ip_card);
+
+    /* Separador */
+    gtk_box_append(GTK_BOX(vbox), gtk_separator_new(GTK_ORIENTATION_HORIZONTAL));
+
+    /* Seção 2: Bloquear MACs */
+    GtkWidget *mac_card = make_section("Bloquear Endereços MAC",
+                                       "ex: aa:bb:cc:dd:ee:ff",
+                                       &app.block_macs,
+                                       &app.mac_switch, &app.mac_entry, &app.mac_list);
+    gtk_box_append(GTK_BOX(vbox), mac_card);
+
+    /* Separador */
+    gtk_box_append(GTK_BOX(vbox), gtk_separator_new(GTK_ORIENTATION_HORIZONTAL));
+
+    /* Seção 3: Bloquear Broadcast */
+    GtkWidget *bcast_card = make_section("Bloquear Broadcast (UDP:4445)",
+                                         "ex: 26.10.20.30",
+                                         &app.block_broadcast,
+                                         &app.bcast_switch, &app.bcast_entry, &app.bcast_list);
+    gtk_box_append(GTK_BOX(vbox), bcast_card);
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), vbox);
+    gtk_window_set_child(GTK_WINDOW(window), scrolled);
+    gtk_window_present(GTK_WINDOW(window));
+
+    /* Escreve configuração inicial se o arquivo não existir */
+    struct stat st;
+    if (stat(FILTER_PATH, &st) != 0)
+        write_json();
+}
+
+int main(int argc, char *argv[])
+{
+    memset(&app, 0, sizeof(app));
+
+    GtkApplication *gtk_app = gtk_application_new("org.radminvpn.filterui",
+                                                  G_APPLICATION_DEFAULT_FLAGS);
+    g_signal_connect(gtk_app, "activate", G_CALLBACK(on_activate), NULL);
+
+    int ret = g_application_run(G_APPLICATION(gtk_app), argc, argv);
+    g_object_unref(gtk_app);
+
+    /* Limpeza */
+    free_section(&app.block_ips);
+    free_section(&app.block_macs);
+    free_section(&app.block_broadcast);
+
+    return ret;
+}

--- a/src/rvpn_launcher.c
+++ b/src/rvpn_launcher.c
@@ -20,14 +20,26 @@ int main(int argc, char *argv[])
 
     snprintf(cmdline, sizeof(cmdline), "%s\\RvControlSvc.exe", exe_dir);
 
-    /* Build command line with original args */
+    /* Build command line with original args (with bounds checking) */
     for (i = 1; i < argc; i++) {
+        size_t current_len = strlen(cmdline);
+        size_t arg_len = strlen(argv[i]);
+        size_t space_needed = arg_len + 1; /* +1 for space */
+        
+        if (current_len + space_needed >= sizeof(cmdline)) {
+            printf("Error: Command line too long (max %zu bytes)\n", sizeof(cmdline));
+            return 1;
+        }
+        
         strcat(cmdline, " ");
         strcat(cmdline, argv[i]);
     }
 
-    /* Create the service process suspended */
-    if (!CreateProcessA(NULL, cmdline, NULL, NULL, FALSE,
+    /* Create the service process suspended.
+     * bInheritHandles=TRUE so the child's stderr (Wine +seh crash backtrace)
+     * flows to our stdout/stderr → /tmp/radmin_service.log when WINEDEBUG
+     * exposes the seh channel. */
+    if (!CreateProcessA(NULL, cmdline, NULL, NULL, TRUE,
                         CREATE_SUSPENDED, NULL, exe_dir, &si, &pi)) {
         printf("CreateProcess failed: %lu\n", GetLastError());
         return 1;

--- a/src/rvpnnetmp.c
+++ b/src/rvpnnetmp.c
@@ -52,30 +52,56 @@ typedef struct _DEVICE_EXTENSION {
 /* Forward decl — we need the device object in the RX thread for TLV encoding */
 static PDEVICE_OBJECT g_DeviceObject = NULL;
 
-/* ============ Logging ============ */
+/* ============ Logging (buffered) ============ */
+
+#define LOG_BUF_SIZE 4096
+
+static HANDLE  g_log_file = NULL;
+static KSPIN_LOCK g_log_lock;
+static CHAR    g_log_buf[LOG_BUF_SIZE];
+static ULONG   g_log_buf_pos = 0;
+static ULONG   g_log_call_count = 0;
+
+/* Flush buffered log data to disk. Caller must hold g_log_lock. */
+static void drv_log_flush_locked(void)
+{
+    if (!g_log_file || g_log_buf_pos == 0)
+        return;
+
+    IO_STATUS_BLOCK iosb;
+    ZwWriteFile(g_log_file, NULL, NULL, NULL, &iosb,
+                g_log_buf, g_log_buf_pos, NULL, NULL);
+    g_log_buf_pos = 0;
+}
 
 static void drv_log(const char *msg)
 {
-    UNICODE_STRING fileName;
-    OBJECT_ATTRIBUTES oa;
-    IO_STATUS_BLOCK iosb;
-    HANDLE hFile;
-    NTSTATUS st;
+    if (!g_log_file)
+        return;
 
-    RtlInitUnicodeString(&fileName, L"\\??\\C:\\radmin_driver.log");
-    InitializeObjectAttributes(&oa, &fileName, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
+    ULONG msgLen = 0;
+    const char *p = msg;
+    while (*p++) msgLen++;
 
-    st = ZwCreateFile(&hFile, FILE_APPEND_DATA | SYNCHRONIZE, &oa, &iosb,
-                      NULL, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ | FILE_SHARE_WRITE,
-                      FILE_OPEN_IF, FILE_SYNCHRONOUS_IO_NONALERT, NULL, 0);
-    if (NT_SUCCESS(st)) {
-        ULONG len = 0;
-        const char *p = msg;
-        while (*p++) len++;
-        ZwWriteFile(hFile, NULL, NULL, NULL, &iosb, (PVOID)msg, len, NULL, NULL);
-        ZwWriteFile(hFile, NULL, NULL, NULL, &iosb, (PVOID)"\r\n", 2, NULL, NULL);
-        ZwClose(hFile);
-    }
+    KIRQL oldIrql;
+    KeAcquireSpinLock(&g_log_lock, &oldIrql);
+
+    /* Flush first if this message (+ CRLF) would overflow the buffer */
+    if (g_log_buf_pos + msgLen + 2 > LOG_BUF_SIZE)
+        drv_log_flush_locked();
+
+    RtlCopyMemory(g_log_buf + g_log_buf_pos, msg, msgLen);
+    g_log_buf_pos += msgLen;
+    RtlCopyMemory(g_log_buf + g_log_buf_pos, "\r\n", 2);
+    g_log_buf_pos += 2;
+
+    /* Flush every 8 calls so data reaches disk even if we crash before the
+     * buffer fills.  Keeping a counter avoids a ZwWriteFile on every call
+     * while still giving good coverage for a 4 KB buffer. */
+    if (++g_log_call_count % 8 == 0)
+        drv_log_flush_locked();
+
+    KeReleaseSpinLock(&g_log_lock, oldIrql);
 }
 
 static void hex32(char *out, ULONG val)
@@ -162,8 +188,8 @@ static volatile LONG g_icmp_tx = 0;   /* service → TAP (inbound ICMP) */
 #define RX_FRAME_MAX 1600
 
 typedef struct _RX_RING {
-    volatile LONG write_idx;
-    volatile LONG read_idx;
+    volatile ULONG write_idx;
+    volatile ULONG read_idx;
     struct {
         USHORT len;
         UCHAR  data[RX_FRAME_MAX];
@@ -179,7 +205,7 @@ static RX_RING g_rx_ring;
  * completion to the correct ReadFile caller. This is what the real
  * NDIS miniport driver does (confirmed from RE of NetMP60_1_1_64.sys). */
 
-#define IRP_QUEUE_SIZE 256
+#define IRP_QUEUE_SIZE 1024
 
 static struct {
     KSPIN_LOCK Lock;
@@ -492,15 +518,17 @@ static void __stdcall rx_thread_proc(PVOID context)
                     if (found) {
                         complete_read_irp(found, frameBuf, frameLen);
                         InterlockedIncrement(&g_irp_completed);
+                    } else {
+                        static LONG udrop = 0;
+                        if (InterlockedIncrement(&udrop) <= 3)
+                            drv_log("RX unicast no IRP");
                     }
                 } else {
-                    /* No route — fallback: oldest IRP */
-                    PIRP irp = g_irp_queue.Irps[g_irp_queue.Head];
-                    g_irp_queue.Head = (g_irp_queue.Head + 1) % IRP_QUEUE_SIZE;
-                    g_irp_queue.Count--;
+                    /* No route — drop */
+                    static LONG ndrop = 0;
+                    if (InterlockedIncrement(&ndrop) <= 3)
+                        drv_log("RX no route");
                     KeReleaseSpinLock(&g_irp_queue.Lock, oldIrql);
-                    complete_read_irp(irp, frameBuf, frameLen);
-                    InterlockedIncrement(&g_irp_completed);
                 }
                 continue;
             }
@@ -508,8 +536,8 @@ static void __stdcall rx_thread_proc(PVOID context)
         }
 
         /* No pending IRP — fall back to ring buffer */
-        LONG widx = g_rx_ring.write_idx;
-        LONG ridx = g_rx_ring.read_idx;
+        ULONG widx = g_rx_ring.write_idx;
+        ULONG ridx = g_rx_ring.read_idx;
         if (widx - ridx >= RX_RING_SIZE) {
             InterlockedIncrement(&g_ring_dropped);
             static LONG drops = 0;
@@ -518,10 +546,10 @@ static void __stdcall rx_thread_proc(PVOID context)
             continue;
         }
 
-        LONG slot = widx % RX_RING_SIZE;
+        ULONG slot = widx % RX_RING_SIZE;
         RtlCopyMemory(g_rx_ring.frames[slot].data, frameBuf, frameLen);
         g_rx_ring.frames[slot].len = frameLen;
-        InterlockedIncrement(&g_rx_ring.write_idx);
+        InterlockedIncrement((volatile LONG *)&g_rx_ring.write_idx);
         InterlockedIncrement(&g_ring_enqueued);
     }
 
@@ -709,9 +737,17 @@ static NTSTATUS NTAPI DispatchCleanup(PDEVICE_OBJECT DeviceObject, PIRP Irp)
     }
 
     for (LONG i = 0; i < cancel_n; i++) {
-        cancel_local[i]->IoStatus.Status = STATUS_CANCELLED;
-        cancel_local[i]->IoStatus.Information = 0;
-        IoCompleteRequest(cancel_local[i], IO_NO_INCREMENT);
+        PIRP irp = cancel_local[i];
+        /* Guard against double-completion: Wine sets Irp->Cancel before
+         * dispatching IRP_MJ_CLEANUP (or races us via CloseHandle's internal
+         * cancellation path).  Calling IoCompleteRequest on an IRP that Wine
+         * is already handling causes a use-after-free (0xc0000005 in ntdll).
+         * If the flag is already set, Wine owns the IRP — skip it. */
+        if (irp->Cancel)
+            continue;
+        irp->IoStatus.Status = STATUS_CANCELLED;
+        irp->IoStatus.Information = 0;
+        IoCompleteRequest(irp, IO_NO_INCREMENT);
     }
 
     if (cancel_n > 0) {
@@ -727,23 +763,15 @@ static NTSTATUS NTAPI DispatchCleanup(PDEVICE_OBJECT DeviceObject, PIRP Irp)
     return STATUS_SUCCESS;
 }
 
-/* IOCTL codes.
- *
- * VERSION/STATUS/SETUP/PEERMAC were the original four we reverse-engineered.
- * STATS/FILTER/PEERPROP were recovered later from the real NetMP60 driver's
- * dispatch (FUN_140004f48): the genuine driver answers all seven, and newer
- * RvControlSvc builds poll FILTER (0x224020) as their "is the adapter
- * operational?" check instead of STATUS. If we leave FILTER on the default
- * path (STATUS_SUCCESS, Information=0) the service never sees the 1-byte
- * filter state it expects and loops in "connecting" forever — observed in
- * the field (GitHub issue #7). So we mirror the real driver's full surface. */
-#define IOCTL_RVPN_VERSION  0x0022c004
-#define IOCTL_RVPN_STATUS   0x00224018
-#define IOCTL_RVPN_SETUP    0x0022801c
-#define IOCTL_RVPN_PEERMAC  0x00228014
-#define IOCTL_RVPN_STATS    0x00224010  /* real: copies 0xB8 bytes of NDIS stats */
-#define IOCTL_RVPN_FILTER   0x00224020  /* real: 1 byte = recv-filter all-packets flag (&0x20) */
-#define IOCTL_RVPN_PEERPROP 0x00228024  /* real: sets a per-peer property, returns Info=1 */
+/* IOCTL codes — derived from RvNetMP60.sys RE and RvControlSvc.exe call sites */
+#define IOCTL_RVPN_VERSION    0x0022c004  /* in:8B (ver+mac), out:12B */
+#define IOCTL_RVPN_STATUS     0x00224018  /* in:0, out:4B state */
+#define IOCTL_RVPN_CONNECT    0x00224020  /* in:0, out:1B media-connected byte */
+#define IOCTL_RVPN_SETLINK    0x00224010  /* in:0xb8B adapter info, out:0 */
+#define IOCTL_RVPN_SETUP      0x0022801c  /* in:4B mode, out:0 */
+#define IOCTL_RVPN_PEERMAC    0x00228014  /* in:6B MAC, out:0 */
+#define IOCTL_RVPN_SETMAC     0x00228024  /* in/out:various */
+#define IOCTL_RVPN_VERSION2   0x0022c004  /* alias */
 
 static NTSTATUS NTAPI DispatchDeviceControl(PDEVICE_OBJECT DeviceObject, PIRP Irp)
 {
@@ -762,14 +790,6 @@ static NTSTATUS NTAPI DispatchDeviceControl(PDEVICE_OBJECT DeviceObject, PIRP Ir
         LONG sc = InterlockedIncrement(&dext->StatusCount);
         if (sc <= 3 || (sc % 500) == 0)
             drv_log("IOCTL STATUS poll");
-    } else if (ioctl == IOCTL_RVPN_FILTER) {
-        /* Polled in a tight loop by newer service builds — rate-limit like
-         * STATUS so it doesn't fill the prefix's drive (issue #7 logs were
-         * ~190 lines of nothing but this IOCTL). */
-        static LONG fc = 0;
-        LONG c = InterlockedIncrement(&fc);
-        if (c <= 3 || (c % 500) == 0)
-            drv_log("IOCTL FILTER poll");
     } else {
         drv_log_ioctl(ioctl, inLen, outLen,
                       (const UCHAR *)sysBuffer, inLen < outLen ? outLen : inLen);
@@ -802,11 +822,38 @@ static NTSTATUS NTAPI DispatchDeviceControl(PDEVICE_OBJECT DeviceObject, PIRP Ir
         break;
 
     case IOCTL_RVPN_STATUS:
+        /* Returns 4-byte NDIS adapter status. Bit 0 = media present/active.
+         * Service checks: if (status != 0 && (status & 1)) → call IOCTL_RVPN_CONNECT.
+         * We report 1 (connected). */
         if (outLen >= 4 && sysBuffer) {
             *((ULONG *)sysBuffer) = 1;
             info = 4;
         }
         break;
+
+    case IOCTL_RVPN_CONNECT:
+        /* Returns 1-byte media-connected state from NDIS adapter status byte.
+         * Real driver returns: adapter_status_byte & 0x20 (NdisMediaStateConnected flag).
+         * Service uses DeviceIoControl(h, 0x224020, NULL, 0, &out, 1, &br, NULL).
+         * If br==0 (no bytes written), DeviceIoControl returns FALSE → service logs
+         * IOCTL failure and sends CDeviceRemoved message → VPN disconnects.
+         * Must write exactly 1 byte to avoid that failure path. 0x20 = connected. */
+        if (outLen >= 1 && sysBuffer) {
+            *((UCHAR *)sysBuffer) = 0x20;  /* NdisMediaStateConnected */
+            info = 1;
+        }
+        break;
+
+    case IOCTL_RVPN_SETLINK:
+        /* Accepts 0xb8 bytes of adapter info from service. No output.
+         * Used to propagate NDIS link info. Accept silently. */
+        break;
+
+    case IOCTL_RVPN_SETMAC:
+        /* Set/query MAC or connection params. Accept silently. */
+        break;
+
+
 
     case IOCTL_RVPN_SETUP:
         if (inLen >= 4 && sysBuffer) {
@@ -907,41 +954,18 @@ static NTSTATUS NTAPI DispatchDeviceControl(PDEVICE_OBJECT DeviceObject, PIRP Ir
         }
         break;
 
-    case IOCTL_RVPN_FILTER:
-        /* Real driver returns (adapter->recv_filter & 0x20), the "all-packets"
-         * bit. Our virtual adapter forwards every frame unconditionally, so we
-         * always report all-packets mode on (0x20). The service uses this as
-         * its operational gate; returning the byte unblocks the connect path. */
-        if (outLen >= 1 && sysBuffer) {
-            *((UCHAR *)sysBuffer) = 0x20;
-            info = 1;
-        }
+    default: {
+        /* Log every unhandled IOCTL: these complete with info=0 (no output
+         * bytes), which can make RvControlSvc fire CDeviceRemoved if it
+         * checks br==0 on some periodic poll IOCTL we haven't mapped yet. */
+        char ubuf[64] = "IOCTL_UNKNOWN 0x";
+        hex32(ubuf + 16, ioctl);
+        ubuf[24] = ' '; ubuf[25] = 'o'; ubuf[26] = '=';
+        hex32(ubuf + 27, outLen);
+        ubuf[35] = 0;
+        drv_log(ubuf);
         break;
-
-    case IOCTL_RVPN_STATS:
-        /* Real driver copies 0xB8 bytes of NDIS counters. We don't track them —
-         * return a zeroed block so the service's stats poll succeeds rather
-         * than erroring. */
-        if (outLen >= 0xB8 && sysBuffer) {
-            RtlZeroMemory(sysBuffer, 0xB8);
-            info = 0xB8;
-        } else {
-            status = STATUS_BUFFER_TOO_SMALL;
-            info = 0;
-        }
-        break;
-
-    case IOCTL_RVPN_PEERPROP:
-        /* Real driver sets a per-peer property from the input byte and returns
-         * Information=1. We don't model peer objects beyond MAC routing, so we
-         * just acknowledge. */
-        if (outLen >= 1 && sysBuffer)
-            *((UCHAR *)sysBuffer) = 0;
-        info = (outLen >= 1) ? 1 : 0;
-        break;
-
-    default:
-        break;
+    }
     }
 
     Irp->IoStatus.Status = status;
@@ -967,7 +991,7 @@ static NTSTATUS NTAPI DispatchRead(PDEVICE_OBJECT DeviceObject, PIRP Irp)
         return STATUS_DEVICE_NOT_CONNECTED;
     }
 
-    LONG ridx = g_rx_ring.read_idx;
+    ULONG ridx = g_rx_ring.read_idx;
 
     if (ridx < g_rx_ring.write_idx) {
         /* Frames available — TLV-encode as many as fit in the buffer */
@@ -985,10 +1009,10 @@ static NTSTATUS NTAPI DispatchRead(PDEVICE_OBJECT DeviceObject, PIRP Irp)
         PIO_STACK_LOCATION irpSp = IoGetCurrentIrpStackLocation(Irp);
         ULONG bufLen = irpSp->Parameters.Read.Length;
         ULONG totalWritten = 0;
-        LONG framesReturned = 0;
+        ULONG framesReturned = 0;
 
         while (ridx < g_rx_ring.write_idx) {
-            LONG slot = ridx % RX_RING_SIZE;
+            ULONG slot = ridx % RX_RING_SIZE;
             USHORT frameLen = g_rx_ring.frames[slot].len;
 
             ULONG written = tlv_encode_frame(outBuf + totalWritten,
@@ -999,7 +1023,7 @@ static NTSTATUS NTAPI DispatchRead(PDEVICE_OBJECT DeviceObject, PIRP Irp)
                 break;  /* no more room */
 
             totalWritten += written;
-            InterlockedIncrement(&g_rx_ring.read_idx);
+            InterlockedIncrement((volatile LONG *)&g_rx_ring.read_idx);
             InterlockedIncrement(&g_ring_consumed);
             ridx++;
             framesReturned++;
@@ -1037,9 +1061,11 @@ static NTSTATUS NTAPI DispatchRead(PDEVICE_OBJECT DeviceObject, PIRP Irp)
             g_irp_queue.Head = (g_irp_queue.Head + 1) % IRP_QUEUE_SIZE;
             g_irp_queue.Count--;
             KeReleaseSpinLock(&g_irp_queue.Lock, oldIrql);
-            oldIrp->IoStatus.Status = STATUS_CANCELLED;
-            oldIrp->IoStatus.Information = 0;
-            IoCompleteRequest(oldIrp, IO_NO_INCREMENT);
+            if (!oldIrp->Cancel) {
+                oldIrp->IoStatus.Status = STATUS_CANCELLED;
+                oldIrp->IoStatus.Information = 0;
+                IoCompleteRequest(oldIrp, IO_NO_INCREMENT);
+            }
             KeAcquireSpinLock(&g_irp_queue.Lock, &oldIrql);
         }
         {
@@ -1186,9 +1212,11 @@ static VOID NTAPI Unload(PDRIVER_OBJECT DriverObject)
             g_irp_queue.Head = (g_irp_queue.Head + 1) % IRP_QUEUE_SIZE;
             g_irp_queue.Count--;
             KeReleaseSpinLock(&g_irp_queue.Lock, oldIrql);
-            irp->IoStatus.Status = STATUS_CANCELLED;
-            irp->IoStatus.Information = 0;
-            IoCompleteRequest(irp, IO_NO_INCREMENT);
+            if (!irp->Cancel) {
+                irp->IoStatus.Status = STATUS_CANCELLED;
+                irp->IoStatus.Information = 0;
+                IoCompleteRequest(irp, IO_NO_INCREMENT);
+            }
             KeAcquireSpinLock(&g_irp_queue.Lock, &oldIrql);
         }
         KeReleaseSpinLock(&g_irp_queue.Lock, oldIrql);
@@ -1205,6 +1233,18 @@ static VOID NTAPI Unload(PDRIVER_OBJECT DriverObject)
         ExFreePoolWithTag(g_peer_routes, PEER_ROUTES_TAG);
         g_peer_routes = NULL;
         g_peer_routes_capacity = 0;
+    }
+
+    /* Flush and close log file */
+    {
+        KIRQL oldIrql;
+        KeAcquireSpinLock(&g_log_lock, &oldIrql);
+        drv_log_flush_locked();
+        KeReleaseSpinLock(&g_log_lock, oldIrql);
+    }
+    if (g_log_file) {
+        ZwClose(g_log_file);
+        g_log_file = NULL;
     }
 }
 
@@ -1235,8 +1275,29 @@ NTSTATUS NTAPI DriverEntry(PDRIVER_OBJECT DriverObject, PUNICODE_STRING Registry
     deviceObject->Flags &= ~DO_DEVICE_INITIALIZING;
 
     RtlZeroMemory(deviceObject->DeviceExtension, sizeof(DEVICE_EXTENSION));
+    RtlZeroMemory(&g_rx_ring, sizeof(g_rx_ring));
     g_DeviceObject = deviceObject;
     KeInitializeSpinLock(&g_irp_queue.Lock);
+    KeInitializeSpinLock(&g_log_lock);
+
+    /* Open log file once; drv_log buffers writes to avoid per-call I/O */
+    {
+        UNICODE_STRING fileName;
+        /* Use Wine's \??\unix\... extension: maps directly to a Linux path,
+         * bypassing the drive-letter translation that fails for regular files
+         * in Wine's fake kernel-mode ZwCreateFile implementation. */
+        RtlInitUnicodeString(&fileName, L"\\??\\unix\\tmp\\radmin_driver.log");
+        OBJECT_ATTRIBUTES oa;
+        InitializeObjectAttributes(&oa, &fileName, OBJ_CASE_INSENSITIVE, NULL, NULL);
+        IO_STATUS_BLOCK iosb;
+        /* OBJ_KERNEL_HANDLE is intentionally omitted: Wine's ntdll does not
+         * honour it in kernel-driver context and silently fails ZwCreateFile
+         * when it is present, leaving g_log_file NULL and all drv_log() calls
+         * as silent no-ops.  Omitting it lets Wine open the file normally. */
+        ZwCreateFile(&g_log_file, FILE_APPEND_DATA | SYNCHRONIZE, &oa, &iosb,
+                     NULL, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                     FILE_OPEN_IF, FILE_SYNCHRONOUS_IO_NONALERT, NULL, 0);
+    }
 
     /* Allocate the initial peer-routes table. Kept small — the table
      * grows on demand via PEERMAC when real peer counts require it. */

--- a/src/tap_bridge.c
+++ b/src/tap_bridge.c
@@ -25,11 +25,52 @@
 #include <errno.h>
 #include <signal.h>
 #include <stdint.h>
+#include <time.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/select.h>
 #include <net/if.h>
 #include <linux/if_tun.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+
+/* ── Filter config (read from /tmp/rvpn_filters.json) ── */
+#define FILTER_PATH    "/tmp/rvpn_filters.json"
+#define MAX_FILTERS    256
+
+typedef struct {
+    int   block_ips_enabled;
+    char  blocked_ips[MAX_FILTERS][48];
+    int   blocked_ips_count;
+    int   block_macs_enabled;
+    char  blocked_macs[MAX_FILTERS][18];
+    int   blocked_macs_count;
+    int   block_broadcast_enabled;
+    char  broadcast_block_ips[MAX_FILTERS][48];
+    int   broadcast_block_ips_count;
+} filter_cfg_t;
+
+static filter_cfg_t filters;
+static time_t       filters_mtime = 0;
+static unsigned long drop_ip = 0, drop_mac = 0, drop_bcast = 0;
+
+/* ── ARP snoop cache ── */
+#define ARP_CACHE_SIZE 256
+#define ARP_CACHE_TTL_SEC 600
+
+typedef struct {
+    uint8_t  ip[4];
+    uint8_t  mac[6];
+    time_t   last_seen;
+    int      valid;
+} arp_cache_entry_t;
+
+static arp_cache_entry_t g_arp_cache[ARP_CACHE_SIZE];
+static int               g_arp_cache_count = 0;
+static unsigned long     g_arp_replies_sent = 0;
+static unsigned long     g_arp_snooped = 0;
+static uint8_t           g_local_ip[4] = {0};
+static int               g_have_local_ip = 0;
 
 #define TAP_DEV_NAME    "radminvpn0"
 #define FIFO_B2D        "/tmp/rvpn_b2d"
@@ -39,7 +80,95 @@
 
 static volatile int running = 1;
 
+/* Signal handler for graceful shutdown */
 static void sig_handler(int sig) { (void)sig; running = 0; }
+
+/* Forward declaration */
+static int write_exact(int fd, const void *buf, size_t n);
+
+/* Recalculate IP header checksum for a frame (eth + IP header) */
+static void fix_ip_checksum(uint8_t *frame)
+{
+    uint8_t ihl = (frame[14] & 0x0F) * 4;
+    frame[24] = 0; frame[25] = 0;
+    uint32_t sum = 0;
+    for (int i = 0; i < ihl; i += 2)
+        sum += ((uint32_t)frame[14 + i] << 8) | frame[15 + i];
+    while (sum >> 16) sum = (sum & 0xFFFF) + (sum >> 16);
+    uint16_t csum = ~((uint16_t)sum);
+    frame[24] = (csum >> 8) & 0xFF;
+    frame[25] = csum & 0xFF;
+}
+
+/* Write a frame to either FIFO ([len16][frame]) or TAP (raw frame) */
+static int write_frame(int fd, const uint8_t *data, uint16_t len, int is_fifo)
+{
+    if (is_fifo) {
+        if (write_exact(fd, &len, 2) < 0 ||
+            write_exact(fd, data, len) < 0)
+            return 0;
+    } else {
+        if (write_exact(fd, data, len) < 0)
+            return 0;
+    }
+    return 1;
+}
+
+/* Minecraft LAN multicast replicator:
+ * Check if an ethernet frame is IPv4 with destination 224.0.2.60.
+ * If so, copy the frame and replicate it as broadcast to both
+ * 26.255.255.255 and 255.255.255.255, with:
+ *   - dest MAC  → ff:ff:ff:ff:ff:ff (broadcast)
+ *   - dest IP   → 26.255.255.255 / 255.255.255.255
+ *   - recalculate IP header checksum
+ *   - zero UDP checksum (valid for IPv4 UDP — checksum is optional)
+ * is_fifo=1: write [len16][frame] to FIFO; is_fifo=0: write raw frame to TAP fd.
+ * Returns number of replicas written (0, 1, or 2). */
+static int replicate_mcast_to_bcast(int write_fd, const uint8_t *frame, uint16_t frame_len, int is_fifo)
+{
+    if (frame_len < 42) return 0;  /* 14 eth + 20 IP + 8 UDP minimum */
+
+    /* Must be IPv4 */
+    if (frame[12] != 0x08 || frame[13] != 0x00) return 0;
+
+    /* Check destination IP at offset 30 (14 eth + 16 IP offset for dst) */
+    if (frame[30] != 224 || frame[31] != 0 || frame[32] != 2 || frame[33] != 60)
+        return 0;
+
+    /* Must be UDP (IP protocol field at offset 23) */
+    if (frame[23] != 17) return 0;
+
+    uint8_t ihl = (frame[14] & 0x0F) * 4;
+    int udp_csum_off = 14 + ihl + 6;  /* UDP checksum offset in frame */
+
+    int count = 0;
+    uint8_t copy[FRAME_MAX];
+    if ((uint16_t)sizeof(copy) < frame_len) return 0;
+
+    /* --- Replica 1: 26.255.255.255 --- */
+    memcpy(copy, frame, frame_len);
+    memset(copy, 0xFF, 6);           /* broadcast MAC */
+    copy[30] = 26; copy[31] = 255; copy[32] = 255; copy[33] = 255;
+    fix_ip_checksum(copy);
+    if (frame_len > (uint16_t)(udp_csum_off + 1)) { copy[udp_csum_off] = 0; copy[udp_csum_off + 1] = 0; }
+    if (write_frame(write_fd, copy, frame_len, is_fifo)) {
+        count++;
+        fprintf(stderr, "tap_bridge: replicated 224.0.2.60 → 26.255.255.255 (%u bytes)\n", frame_len);
+    }
+
+    /* --- Replica 2: 255.255.255.255 --- */
+    memcpy(copy, frame, frame_len);
+    memset(copy, 0xFF, 6);           /* broadcast MAC */
+    copy[30] = 255; copy[31] = 255; copy[32] = 255; copy[33] = 255;
+    fix_ip_checksum(copy);
+    if (frame_len > (uint16_t)(udp_csum_off + 1)) { copy[udp_csum_off] = 0; copy[udp_csum_off + 1] = 0; }
+    if (write_frame(write_fd, copy, frame_len, is_fifo)) {
+        count++;
+        fprintf(stderr, "tap_bridge: replicated 224.0.2.60 → 255.255.255.255 (%u bytes)\n", frame_len);
+    }
+
+    return count;
+}
 
 /* Read exactly n bytes (blocking) */
 static int read_exact(int fd, void *buf, size_t n)
@@ -47,7 +176,12 @@ static int read_exact(int fd, void *buf, size_t n)
     size_t done = 0;
     while (done < n) {
         ssize_t r = read(fd, (char *)buf + done, n - done);
-        if (r <= 0) return -1;
+        if (r < 0) {
+            if (errno == EINTR || errno == EAGAIN)
+                continue;
+            return -1;
+        }
+        if (r == 0) return -1;
         done += r;
     }
     return 0;
@@ -59,13 +193,20 @@ static int write_exact(int fd, const void *buf, size_t n)
     size_t done = 0;
     while (done < n) {
         ssize_t w = write(fd, (const char *)buf + done, n - done);
-        if (w <= 0) return -1;
+        if (w < 0) {
+            if (errno == EINTR || errno == EAGAIN)
+                continue;
+            return -1;
+        }
+        if (w == 0) return -1;
         done += w;
     }
     return 0;
 }
 
-/* Open/attach to the TAP device */
+/* Open/attach to the TAP device
+ * Creates or attaches to an existing TAP device for ethernet frame I/O.
+ * IFF_NO_PI: no packet information header (we want raw ethernet frames) */
 static int open_tap(const char *dev_name)
 {
     struct ifreq ifr;
@@ -83,6 +224,9 @@ static int open_tap(const char *dev_name)
     }
     fprintf(stderr, "tap_bridge: attached to '%s' (fd=%d)\n", ifr.ifr_name, fd);
     return fd;
+/* Create named pipes for communication with Wine driver
+ * FIFO_B2D: bridge-to-driver (TAP → Wine): bridge writes, driver reads
+ * FIFO_D2B: driver-to-bridge (Wine → TAP): driver writes, bridge reads */
 }
 
 static void create_fifos(void)
@@ -92,6 +236,377 @@ static void create_fifos(void)
     mkfifo(FIFO_B2D, 0666);
     mkfifo(FIFO_D2B, 0666);
     fprintf(stderr, "tap_bridge: FIFOs created: %s, %s\n", FIFO_B2D, FIFO_D2B);
+}
+
+/* ── Minimal JSON helpers (no library dependency) ── */
+
+static const char *json_find_key(const char *json, const char *key)
+{
+    char needle[64];
+    snprintf(needle, sizeof(needle), "\"%s\"", key);
+    const char *p = strstr(json, needle);
+    if (!p) return NULL;
+    p += strlen(needle);
+    while (*p == ' ' || *p == '\t' || *p == ':' || *p == '\n' || *p == '\r') p++;
+    return p;
+}
+
+static int json_bool(const char *json, const char *key, int defval)
+{
+    const char *p = json_find_key(json, key);
+    if (!p) return defval;
+    if (strncmp(p, "true", 4) == 0) return 1;
+    if (strncmp(p, "false", 5) == 0) return 0;
+    return defval;
+}
+
+static int json_str_array(const char *json, const char *key,
+                          char *out, int max_out, int elem_size, int max_len)
+{
+    const char *p = json_find_key(json, key);
+    if (!p || *p != '[') return 0;
+    p++; /* skip '[' */
+    int count = 0;
+    while (count < max_out) {
+        while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r' || *p == ',') p++;
+        if (*p == ']' || *p == '\0') break;
+        if (*p != '"') { p++; continue; }
+        p++; /* skip opening quote */
+        char *entry = out + (size_t)count * elem_size;
+        int i = 0;
+        while (*p && *p != '"' && i < max_len - 1) entry[i++] = *p++;
+        entry[i] = '\0';
+        if (*p == '"') p++;
+        count++;
+    }
+    return count;
+}
+
+/* Load filter config from JSON file. Only reloads if file mtime changed. */
+static void load_filters(void)
+{
+    struct stat st;
+    if (stat(FILTER_PATH, &st) != 0) return;
+    if (st.st_mtime == filters_mtime) return;  /* unchanged */
+    filters_mtime = st.st_mtime;
+
+    FILE *f = fopen(FILTER_PATH, "r");
+    if (!f) return;
+    fseek(f, 0, SEEK_END);
+    long sz = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (sz <= 0 || sz > 65536) { fclose(f); return; }
+    char *buf = malloc((size_t)sz + 1);
+    if (!buf) { fclose(f); return; }
+    size_t rd = fread(buf, 1, (size_t)sz, f);
+    fclose(f);
+    buf[rd] = '\0';
+
+    memset(&filters, 0, sizeof(filters));
+    filters.block_ips_enabled       = json_bool(buf, "block_ips_enabled", 0);
+    filters.block_macs_enabled      = json_bool(buf, "block_macs_enabled", 0);
+    filters.block_broadcast_enabled = json_bool(buf, "block_broadcast_enabled", 0);
+    filters.blocked_ips_count       = json_str_array(buf, "blocked_ips",
+                                        (char *)filters.blocked_ips, MAX_FILTERS, 48, 48);
+    filters.blocked_macs_count      = json_str_array(buf, "blocked_macs",
+                                        (char *)filters.blocked_macs, MAX_FILTERS, 18, 18);
+    filters.broadcast_block_ips_count = json_str_array(buf, "broadcast_block_ips",
+                                        (char *)filters.broadcast_block_ips, MAX_FILTERS, 48, 48);
+    free(buf);
+    fprintf(stderr, "tap_bridge: filters loaded (ip=%d/%d mac=%d/%d bcast=%d/%d)\n",
+            filters.block_ips_enabled, filters.blocked_ips_count,
+            filters.block_macs_enabled, filters.blocked_macs_count,
+            filters.block_broadcast_enabled, filters.broadcast_block_ips_count);
+}
+
+/* Parse "A.B.C.D" into 4 bytes. Returns 0 on success. */
+static int parse_ip(const char *s, uint8_t out[4])
+{
+    unsigned a, b, c, d;
+    if (sscanf(s, "%u.%u.%u.%u", &a, &b, &c, &d) != 4) return -1;
+    if (a > 255 || b > 255 || c > 255 || d > 255) return -1;
+    out[0] = (uint8_t)a; out[1] = (uint8_t)b;
+    out[2] = (uint8_t)c; out[3] = (uint8_t)d;
+    return 0;
+}
+
+/* Parse "aa:bb:cc:dd:ee:ff" into 6 bytes. Returns 0 on success. */
+static int parse_mac(const char *s, uint8_t out[6])
+{
+    unsigned m[6];
+    if (sscanf(s, "%x:%x:%x:%x:%x:%x",
+              &m[0], &m[1], &m[2], &m[3], &m[4], &m[5]) != 6) return -1;
+    for (int i = 0; i < 6; i++) { if (m[i] > 255) return -1; out[i] = (uint8_t)m[i]; }
+    return 0;
+}
+
+/* Check if an IPv4 address matches any entry in a filter list. */
+static int ip_in_list(const uint8_t ip[4], const char list[][48], int count)
+{
+    for (int i = 0; i < count; i++) {
+        uint8_t fip[4];
+        if (parse_ip(list[i], fip) == 0 &&
+            ip[0] == fip[0] && ip[1] == fip[1] && ip[2] == fip[2] && ip[3] == fip[3])
+            return 1;
+    }
+    return 0;
+}
+
+/* Check if a MAC address matches any entry in a filter list. */
+static int mac_in_list(const uint8_t mac[6], const char list[][18], int count)
+{
+    for (int i = 0; i < count; i++) {
+        uint8_t fmac[6];
+        if (parse_mac(list[i], fmac) == 0 &&
+            memcmp(mac, fmac, 6) == 0)
+            return 1;
+    }
+    return 0;
+}
+
+/* 
+ * should_drop_frame — decide whether a frame should be dropped.
+ * direction: 0 = TAP→driver (outgoing), 1 = driver→TAP (incoming)
+ * Returns: 0 = pass, 1 = drop
+ */
+static int should_drop_frame(const uint8_t *frame, uint16_t len, int direction)
+{
+    if (len < 14) return 0;  /* too short to be ethernet */
+
+    /* ── Block MACs (both directions) ── */
+    if (filters.block_macs_enabled && filters.blocked_macs_count > 0) {
+        const uint8_t *src_mac = frame;
+        const uint8_t *dst_mac = frame + 6;
+        if (mac_in_list(src_mac, filters.blocked_macs, filters.blocked_macs_count) ||
+            mac_in_list(dst_mac, filters.blocked_macs, filters.blocked_macs_count)) {
+            drop_mac++;
+            if (drop_mac <= 5 || (drop_mac % 100) == 0)
+                fprintf(stderr, "tap_bridge: DROP mac #%lu (dir=%s)\n", drop_mac,
+                        direction ? "drv→TAP" : "TAP→drv");
+            return 1;
+        }
+    }
+
+    /* Must be IPv4 for IP-based checks */
+    if (len < 34 || frame[12] != 0x08 || frame[13] != 0x00) return 0;
+
+    /* Validate IPv4 header: version==4 and IHL>=5 (min 20-byte header) */
+    uint8_t ip_ver_ihl = frame[14];
+    if ((ip_ver_ihl >> 4) != 4 || (ip_ver_ihl & 0x0F) < 5) return 0;
+
+    /* Validate IP total length fits within the frame payload */
+    uint16_t ip_total_len = ((uint16_t)frame[16] << 8) | frame[17];
+    if (ip_total_len < 20 || ip_total_len > (len - 14)) return 0;
+
+    const uint8_t *src_ip = frame + 26;
+    const uint8_t *dst_ip = frame + 30;
+
+    /* ── Block IPs (both directions) ── */
+    if (filters.block_ips_enabled && filters.blocked_ips_count > 0) {
+        if (ip_in_list(src_ip, filters.blocked_ips, filters.blocked_ips_count) ||
+            ip_in_list(dst_ip, filters.blocked_ips, filters.blocked_ips_count)) {
+            drop_ip++;
+            if (drop_ip <= 5 || (drop_ip % 100) == 0)
+                fprintf(stderr, "tap_bridge: DROP ip #%lu (dir=%s, src=%u.%u.%u.%u)\n",
+                        drop_ip, direction ? "drv→TAP" : "TAP→drv",
+                        src_ip[0], src_ip[1], src_ip[2], src_ip[3]);
+            return 1;
+        }
+    }
+
+    /* ── Block Broadcast (incoming only: driver→TAP) ── */
+    if (direction == 1 &&
+        filters.block_broadcast_enabled && filters.broadcast_block_ips_count > 0) {
+        /* Must be UDP */
+        if (frame[23] != 17) return 0;
+
+        /* Check if src or dst IP is in broadcast block list */
+        if (ip_in_list(src_ip, filters.broadcast_block_ips, filters.broadcast_block_ips_count) ||
+            ip_in_list(dst_ip, filters.broadcast_block_ips, filters.broadcast_block_ips_count)) {
+            /* Check UDP port 4445 (src or dst) */
+            uint8_t ihl = (frame[14] & 0x0F) * 4;
+            if (len < (uint16_t)(14 + ihl + 8)) return 0;  /* too short for UDP hdr */
+            const uint8_t *udp_hdr = frame + 14 + ihl;
+            uint16_t src_port = ((uint16_t)udp_hdr[0] << 8) | udp_hdr[1];
+            uint16_t dst_port = ((uint16_t)udp_hdr[2] << 8) | udp_hdr[3];
+            if (src_port == 4445 || dst_port == 4445) {
+                drop_bcast++;
+                if (drop_bcast <= 5 || (drop_bcast % 100) == 0)
+                    fprintf(stderr, "tap_bridge: DROP bcast #%lu (ip=%u.%u.%u.%u port=%u/%u)\n",
+                            drop_bcast, src_ip[0], src_ip[1], src_ip[2], src_ip[3],
+                            src_port, dst_port);
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+/* Detect local TAP IP so we don't cache our own MAC */
+static void detect_local_ip(const char *ifname)
+{
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) return;
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
+    if (ioctl(fd, SIOCGIFADDR, &ifr) == 0) {
+        struct sockaddr_in *sin = (struct sockaddr_in *)&ifr.ifr_addr;
+        memcpy(g_local_ip, &sin->sin_addr.s_addr, 4);
+        g_have_local_ip = 1;
+        fprintf(stderr, "tap_bridge: local IP %u.%u.%u.%u\n",
+                g_local_ip[0], g_local_ip[1], g_local_ip[2], g_local_ip[3]);
+    }
+    close(fd);
+}
+
+static int g_tap_fd = -1;  /* global for gratuitous ARP injection */
+
+/* Inject a gratuitous ARP reply into the TAP device so the Linux kernel
+ * learns the IP-MAC mapping immediately, without needing to send its own
+ * ARP request through the tunnel (which takes ~1-2s and drops the first ping). */
+static void inject_gratuitous_arp(const uint8_t ip[4], const uint8_t mac[6])
+{
+    if (g_tap_fd < 0) return;
+
+    uint8_t garp[60];
+    memset(garp, 0, sizeof(garp));
+
+    /* Ethernet header: broadcast destination */
+    memset(garp, 0xFF, 6);           /* dst = broadcast */
+    memcpy(garp + 6, mac, 6);        /* src = announced MAC */
+    garp[12] = 0x08; garp[13] = 0x06; /* ARP */
+
+    /* ARP payload */
+    garp[14] = 0x00; garp[15] = 0x01; /* HTYPE = Ethernet */
+    garp[16] = 0x08; garp[17] = 0x00; /* PTYPE = IPv4 */
+    garp[18] = 6;                      /* HLEN */
+    garp[19] = 4;                      /* PLEN */
+    garp[20] = 0x00; garp[21] = 0x02; /* opcode = reply */
+    memcpy(garp + 22, mac, 6);        /* sender MAC */
+    memcpy(garp + 28, ip, 4);         /* sender IP */
+    memcpy(garp + 32, mac, 6);        /* target MAC */
+    memcpy(garp + 38, ip, 4);         /* target IP */
+
+    if (write(g_tap_fd, garp, 60) == 60) {
+        g_arp_replies_sent++;
+        fprintf(stderr, "tap_bridge: gratuitous ARP for %u.%u.%u.%u -> "
+                "%02x:%02x:%02x:%02x:%02x:%02x\n",
+                ip[0], ip[1], ip[2], ip[3],
+                mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    }
+}
+
+static void arp_cache_update(const uint8_t ip[4], const uint8_t mac[6])
+{
+    if (g_have_local_ip && memcmp(ip, g_local_ip, 4) == 0) return;
+
+    time_t now = time(NULL);
+
+    /* Update existing entry */
+    for (int i = 0; i < g_arp_cache_count; i++) {
+        if (g_arp_cache[i].valid && memcmp(g_arp_cache[i].ip, ip, 4) == 0) {
+            memcpy(g_arp_cache[i].mac, mac, 6);
+            g_arp_cache[i].last_seen = now;
+            return;
+        }
+    }
+
+    /* Reuse expired slot */
+    for (int i = 0; i < g_arp_cache_count; i++) {
+        if (!g_arp_cache[i].valid ||
+            (now - g_arp_cache[i].last_seen) > ARP_CACHE_TTL_SEC) {
+            memcpy(g_arp_cache[i].ip, ip, 4);
+            memcpy(g_arp_cache[i].mac, mac, 6);
+            g_arp_cache[i].last_seen = now;
+            g_arp_cache[i].valid = 1;
+            g_arp_snooped++;
+            inject_gratuitous_arp(ip, mac);
+            return;
+        }
+    }
+
+    /* Append if room */
+    if (g_arp_cache_count < ARP_CACHE_SIZE) {
+        int i = g_arp_cache_count++;
+        memcpy(g_arp_cache[i].ip, ip, 4);
+        memcpy(g_arp_cache[i].mac, mac, 6);
+        g_arp_cache[i].last_seen = now;
+        g_arp_cache[i].valid = 1;
+        g_arp_snooped++;
+        inject_gratuitous_arp(ip, mac);
+        return;
+    }
+
+    /* Overwrite oldest */
+    int oldest = 0;
+    for (int i = 1; i < ARP_CACHE_SIZE; i++) {
+        if (g_arp_cache[i].last_seen < g_arp_cache[oldest].last_seen)
+            oldest = i;
+    }
+    memcpy(g_arp_cache[oldest].ip, ip, 4);
+    memcpy(g_arp_cache[oldest].mac, mac, 6);
+    g_arp_cache[oldest].last_seen = now;
+    g_arp_cache[oldest].valid = 1;
+    g_arp_snooped++;
+    inject_gratuitous_arp(ip, mac);
+}
+
+static int arp_cache_lookup(const uint8_t ip[4], uint8_t out_mac[6])
+{
+    time_t now = time(NULL);
+    for (int i = 0; i < g_arp_cache_count; i++) {
+        if (g_arp_cache[i].valid && memcmp(g_arp_cache[i].ip, ip, 4) == 0) {
+            if ((now - g_arp_cache[i].last_seen) <= ARP_CACHE_TTL_SEC) {
+                memcpy(out_mac, g_arp_cache[i].mac, 6);
+                return 1;
+            }
+            g_arp_cache[i].valid = 0;
+        }
+    }
+    return 0;
+}
+
+/* If frame is an ARP request whose target IP is in cache, inject reply on tap_fd */
+static int try_arp_reply(int tap_fd, const uint8_t *frame, uint16_t len)
+{
+    if (len < 42) return 0;
+    if (frame[12] != 0x08 || frame[13] != 0x06) return 0;  /* not ARP */
+    if (frame[20] != 0x00 || frame[21] != 0x01) return 0;  /* not request */
+
+    const uint8_t *target_ip = frame + 38;
+    uint8_t cached_mac[6];
+    if (!arp_cache_lookup(target_ip, cached_mac)) return 0;
+
+    uint8_t reply[60];
+    memset(reply, 0, sizeof(reply));
+
+    /* Ethernet header */
+    memcpy(reply, frame + 6, 6);        /* dest = requester MAC */
+    memcpy(reply + 6, cached_mac, 6);   /* src = cached target MAC */
+    reply[12] = 0x08; reply[13] = 0x06; /* ARP ethertype */
+
+    /* ARP payload */
+    reply[14] = 0x00; reply[15] = 0x01; /* HTYPE = Ethernet */
+    reply[16] = 0x08; reply[17] = 0x00; /* PTYPE = IPv4 */
+    reply[18] = 6;                      /* HLEN */
+    reply[19] = 4;                      /* PLEN */
+    reply[20] = 0x00; reply[21] = 0x02; /* opcode = reply */
+    memcpy(reply + 22, cached_mac, 6);  /* sender MAC */
+    memcpy(reply + 28, target_ip, 4);   /* sender IP */
+    memcpy(reply + 32, frame + 6, 6);   /* target MAC = requester */
+    memcpy(reply + 38, frame + 28, 4);  /* target IP = requester IP */
+
+    if (write(tap_fd, reply, 60) == 60) {
+        g_arp_replies_sent++;
+        if (g_arp_replies_sent <= 5 || (g_arp_replies_sent % 50) == 0)
+            fprintf(stderr, "tap_bridge: ARP reply #%lu for %u.%u.%u.%u\n",
+                    g_arp_replies_sent,
+                    target_ip[0], target_ip[1], target_ip[2], target_ip[3]);
+        return 1;
+    }
+    return 0;
 }
 
 int main(int argc, char *argv[])
@@ -105,6 +620,9 @@ int main(int argc, char *argv[])
     /* Attach to existing TAP (created by run.sh with ip tuntap add) */
     int tap_fd = open_tap(TAP_DEV_NAME);
     if (tap_fd < 0) return 1;
+    g_tap_fd = tap_fd;  /* for gratuitous ARP injection */
+
+    detect_local_ip(TAP_DEV_NAME);
 
     /* Create FIFOs */
     create_fifos();
@@ -129,6 +647,9 @@ int main(int argc, char *argv[])
 
     unsigned long tap_to_drv = 0, drv_to_tap = 0;
 
+    /* Initial filter load */
+    load_filters();
+
     while (running) {
         FD_ZERO(&rfds);
         FD_SET(tap_fd, &rfds);
@@ -141,22 +662,39 @@ int main(int argc, char *argv[])
             perror("select");
             break;
         }
-        if (ret == 0) continue;
+        if (ret == 0) {
+            /* Poll for filter config changes every ~1s */
+            load_filters();
+            continue;
+        }
 
         /* TAP → driver (b2d FIFO): read frame from TAP, write [len16][frame] */
         if (FD_ISSET(tap_fd, &rfds)) {
             ssize_t n = read(tap_fd, buf, sizeof(buf));
             if (n > 0) {
                 uint16_t len = (uint16_t)n;
+                /* Snoop outbound ARP packets to pre-populate cache */
+                if (len >= 42 && buf[12] == 0x08 && buf[13] == 0x06) {
+                    arp_cache_update(buf + 28, buf + 22);  /* sender IP, sender MAC */
+                }
+                /* ARP proxy: if we have a cached MAC for the target IP, reply locally.
+                 * Always forward the ARP request through the tunnel too — the remote
+                 * peer needs to see it to learn our MAC, otherwise return-path ARP
+                 * resolution delays cause the first 2 pings to drop. */
+                try_arp_reply(tap_fd, buf, len);
+                if (should_drop_frame(buf, len, 0)) goto skip_tap_to_drv;
                 if (write_exact(b2d_fd, &len, 2) < 0 ||
                     write_exact(b2d_fd, buf, len) < 0) {
                     fprintf(stderr, "tap_bridge: b2d write failed\n");
                     break;
                 }
                 tap_to_drv++;
+                /* Replicate multicast 224.0.2.60 as broadcast 26.255.255.255 */
+                replicate_mcast_to_bcast(b2d_fd, buf, len, 1);
                 if (tap_to_drv <= 5 || (tap_to_drv % 100) == 0)
                     fprintf(stderr, "tap_bridge: TAP→drv #%lu (%d bytes)\n", tap_to_drv, (int)n);
             }
+            skip_tap_to_drv: ;
         }
 
         /* Driver → TAP (d2b FIFO): read [len16][frame], write frame to TAP */
@@ -174,16 +712,33 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "tap_bridge: d2b read frame failed\n");
                 break;
             }
+            /* Snoop IPv4 packets from tunnel to pre-populate ARP cache */
+            if (len >= 34 && buf[12] == 0x08 && buf[13] == 0x00) {
+                arp_cache_update(buf + 26, buf + 6);
+            }
+            /* Snoop ARP packets (requests & replies) from tunnel */
+            if (len >= 42 && buf[12] == 0x08 && buf[13] == 0x06) {
+                arp_cache_update(buf + 28, buf + 22);  /* sender IP, sender MAC */
+            }
+            if (should_drop_frame(buf, len, 1)) goto skip_drv_to_tap;
             if (write(tap_fd, buf, len) != (ssize_t)len) {
                 perror("tap_bridge: write to TAP");
             }
+            /* Replicate multicast 224.0.2.60 as broadcast 26.255.255.255 */
+            replicate_mcast_to_bcast(tap_fd, buf, len, 0);
             drv_to_tap++;
-            if (drv_to_tap <= 5 || (drv_to_tap % 100) == 0)
-                fprintf(stderr, "tap_bridge: drv→TAP #%lu (%u bytes)\n", drv_to_tap, len);
+            if (drv_to_tap <= 5 || (drv_to_tap % 100) == 0) {
+                fprintf(stderr, "tap_bridge: drv→TAP #%lu (%u bytes) hex: ", drv_to_tap, len);
+                for(int i=0; i < (len < 32 ? len : 32); i++) fprintf(stderr, "%02x ", buf[i]);
+                fprintf(stderr, "\n");
+            }
+            skip_drv_to_tap: ;
         }
     }
 
-    fprintf(stderr, "tap_bridge: shutting down (TAP→drv=%lu, drv→TAP=%lu)\n", tap_to_drv, drv_to_tap);
+    fprintf(stderr, "tap_bridge: shutting down (TAP→drv=%lu, drv→TAP=%lu, drops: ip=%lu mac=%lu bcast=%lu, arp: snooped=%lu replies=%lu)\n",
+            tap_to_drv, drv_to_tap, drop_ip, drop_mac, drop_bcast,
+            g_arp_snooped, g_arp_replies_sent);
     close(d2b_fd);
     close(b2d_fd);
     close(tap_fd);


### PR DESCRIPTION
This PR ports a Linux-focused stability/usability fork on top of upstream. It targets the crashes and rough edges hit when running Radmin VPN under Wine, and adds optional headless / datacenter launch modes.

## Highlights

- **Driver (`rvpnnetmp.c`)** — added `IOCTL_RVPN_CONNECT` (reports media-connected, stops `CDeviceRemoved` → disconnect), `SETLINK`/`SETMAC` handlers, double-completion guard on cancel/cleanup (fixes a Wine use-after-free), drop-instead-of-misroute on no-MAC-match, buffered spinlock-guarded logging, larger IRP queue, unsigned ring indices.
- **`adapter_hook.c`** — vectored crash handler writing full dumps; runtime fix for the dangling-`INetwork` service crash (stubs `rvpn::GetINetwork`) plus a `setjmp/longjmp` task-guard safety net; checked `VirtualProtect`.
- **`tap_bridge.c`** — packet-filter engine (IP/MAC/broadcast via `/tmp/rvpn_filters.json`), ARP snoop cache + gratuitous-ARP injection (kills the first-ping delay) + ARP proxy, Minecraft LAN multicast replicator, `EINTR/EAGAIN`-robust I/O.
- **`netsh_wrapper.c` / `rvpn_launcher.c`** — bounds checks, `interface ip set address` support, `bInheritHandles=TRUE` so Wine `+seh` backtraces reach the service log.
- **Packaging / build** — cross-distro DDK + lib detection, strip+UPX post-build, dependency installers, `netsh64.exe` (64-bit) + optional GTK4 filter-UI build targets. CI builds `libgtk-4-dev` and publishes the new artifacts.
- **Scripts** — `health_check.sh` diagnostics, `run_datacenter.sh` (Xvfb + x11vnc + noVNC), `run_vps.sh` (fast headless), `RVPN_DEBUG=1` debug bundle.

## New opt-in flags in `run.sh`
- `--filter-ui` — launch the GTK4 packet-filter UI (off by default).
- `--fix-chat` — patch Qt `qwindows.dll` to fix the chat crash (off by default).

Both are documented in the README.

## Notes / non-goals
- The proprietary Radmin installer is **never bundled** in the AppImage — it is downloaded at runtime (`RADMIN_INSTALLER_URL`).
- No branding changes; upstream `.desktop` and SVG icon are kept.

## Heads-up for review
This fork's history is unrelated to current `main` (no common merge-base) — it was based on an older upstream. `src/rvpnnetmp.c` and `run.sh` are therefore wholesale replacements rather than merges, so the diff on those two files may appear to revert some recent `#12` work. Happy to hand-merge those if preferred.
