### PR TITLE
fix(hook): correct RvControlSvc RVAs to fix data-plane crash and handle LD_PRELOAD spaces

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -456,9 +456,11 @@ _svc_winedebug="-all"
 # filter UI started later; guarded so a missing .so cannot break the launch.
 (
     if [ -f "$BUILD_DIR/rvpn_dnsfix.so" ]; then
+        # Copy to /tmp to avoid LD_PRELOAD parsing issues when BUILD_DIR contains spaces.
+        cp -f "$BUILD_DIR/rvpn_dnsfix.so" /tmp/rvpn_dnsfix.so
         # Prepend, never overwrite: gamemode/mangohud/obs-vkcapture users have
         # their own LD_PRELOAD and would silently lose it for this process.
-        export LD_PRELOAD="$BUILD_DIR/rvpn_dnsfix.so${LD_PRELOAD:+:$LD_PRELOAD}"
+        export LD_PRELOAD="/tmp/rvpn_dnsfix.so${LD_PRELOAD:+:$LD_PRELOAD}"
     else
         warn "rvpn_dnsfix.so missing — private reverse-DNS stalls are not mitigated"
     fi

--- a/run_datacenter.sh
+++ b/run_datacenter.sh
@@ -410,7 +410,8 @@ cd "$RADMIN"
 # a docker0 hits the same black-holed PTR stall as a desktop. See run.sh.
 (
     if [ -f "$BUILD_DIR/rvpn_dnsfix.so" ]; then
-        export LD_PRELOAD="$BUILD_DIR/rvpn_dnsfix.so${LD_PRELOAD:+:$LD_PRELOAD}"
+        cp -f "$BUILD_DIR/rvpn_dnsfix.so" /tmp/rvpn_dnsfix.so
+        export LD_PRELOAD="/tmp/rvpn_dnsfix.so${LD_PRELOAD:+:$LD_PRELOAD}"
     else
         warn "rvpn_dnsfix.so missing — private reverse-DNS stalls are not mitigated"
     fi

--- a/run_vps.sh
+++ b/run_vps.sh
@@ -231,7 +231,8 @@ cd "$RADMIN"
 # a docker0 hits the same black-holed PTR stall as a desktop. See run.sh.
 (
     if [ -f "$BUILD_DIR/rvpn_dnsfix.so" ]; then
-        export LD_PRELOAD="$BUILD_DIR/rvpn_dnsfix.so${LD_PRELOAD:+:$LD_PRELOAD}"
+        cp -f "$BUILD_DIR/rvpn_dnsfix.so" /tmp/rvpn_dnsfix.so
+        export LD_PRELOAD="/tmp/rvpn_dnsfix.so${LD_PRELOAD:+:$LD_PRELOAD}"
     else
         warn "rvpn_dnsfix.so missing — private reverse-DNS stalls are not mitigated"
     fi

--- a/src/adapter_hook.c
+++ b/src/adapter_hook.c
@@ -223,9 +223,9 @@ static LONG CALLBACK crash_handler(PEXCEPTION_POINTERS ep)
  * The setjmp scope == the entire task, so recovery never unwinds to a stale
  * frame. Installed from DllMain before any task runs. */
 
-#define DISPATCH_RVA 0x636A0        /* sub_4636A0 worker entry          */
-#define FREE_RVA     0xC9001        /* sub_4C9001 = operator delete(p,n) */
-#define COUNTER_RVA  0x13F1D8       /* dword_53F1D8 pending-task count   */
+#define DISPATCH_RVA 0x788C0        /* sub_4788C0 worker entry          */
+#define FREE_RVA     0xE5807        /* sub_4E5807 = operator delete(p,n) */
+#define COUNTER_RVA  0x15C778       /* dword_55C778 pending-task count   */
 
 static BYTE *g_rvbase = NULL;       /* RvControlSvc.exe load base */
 
@@ -272,11 +272,11 @@ static unsigned __stdcall hook_dispatch(void **Block)
     return 0;
 }
 
-#define GETINETWORK_RVA 0x5BA70     /* sub_45BA70 rvpn::GetINetwork getter */
+#define GETINETWORK_RVA 0x67D00     /* sub_467D00 rvpn::GetINetwork getter */
 
 static void install_release_guard(void)
 {
-    /* sub_4636A0 prologue: push ebp; mov ebp,esp; push -1 (55 8B EC 6A FF). */
+    /* sub_4788C0 prologue: push ebp; mov ebp,esp; push -1 (55 8B EC 6A FF). */
     static const BYTE expect[5] = { 0x55, 0x8B, 0xEC, 0x6A, 0xFF };
     HMODULE base = GetModuleHandleA(NULL);
     BYTE *t;
@@ -288,15 +288,15 @@ static void install_release_guard(void)
     }
     g_rvbase = (BYTE *)base;
 
-    /* PRIMARY FIX -- neutralise rvpn::GetINetwork (sub_45BA70, +0x5BA70). It
-     * caches a Wine netprofm INetwork at CSetupAdapter+0x1D4; Wine frees that
+    /* PRIMARY FIX -- neutralise rvpn::GetINetwork (sub_467D00, +0x67D00). It
+     * caches a Wine netprofm INetwork at CSetupAdapter+0x1D8; Wine frees that
      * object on network changes ("netprofm: no support for detecting network
      * changes"), so every later GetName/SetName/release through the stale
-     * pointer faults (0xc0000005 @ 0x043304A3) when joining a busy server. The
-     * function already has a handled "failed -> return 0" path, so stub it to
-     * always return 0: the service skips the network naming (a no-op under
-     * Wine's stub netprofm anyway) and the setup task completes normally, adapter
-     * intact. __thiscall, bool in AL, no stack args -> `xor al,al; ret`. */
+     * pointer faults (0xc0000005 @ 0x043304A3 / sub_466900) when joining a
+     * busy server. The function already has a handled "failed -> return 0" path,
+     * so stub it to always return 0: the service skips the network naming (a
+     * no-op under Wine's stub netprofm anyway) and the setup task completes
+     * normally, adapter intact. __thiscall, bool in AL, no stack args -> `xor al,al; ret`. */
     {
         static const BYTE gi_expect[3] = { 0x56, 0x57, 0x8B };  /* push esi;push edi;mov edi,ecx */
         BYTE *g = (BYTE *)base + GETINETWORK_RVA;
@@ -310,7 +310,7 @@ static void install_release_guard(void)
             g[2] = 0xC3;                         /* ret        */
             VirtualProtect(g, 3, go, &go);
             FlushInstructionCache(GetCurrentProcess(), g, 3);
-            dbg("GetINetwork stubbed at RvControlSvc+0x5BA70 (always return 0)");
+            dbg("GetINetwork stubbed at RvControlSvc+0x67D00 (always return 0)");
         }
     }
 
@@ -332,7 +332,7 @@ static void install_release_guard(void)
     t[5] = 0xC3;
     VirtualProtect(t, 6, old, &old);
     FlushInstructionCache(GetCurrentProcess(), t, 6);
-    dbg("task-guard installed at RvControlSvc+0x636A0");
+    dbg("task-guard installed at RvControlSvc+0x788C0");
 }
 
 /* ====== Adapter-list filtering (issue #16) ======
@@ -973,7 +973,7 @@ static BOOL hook_import(HMODULE mod, const char *dll, const char *fn, WORD ord,
                 match = (strcmp(bn->Name, fn) == 0);
             }
             if (!match) continue;
-            if (saved) *saved = (void *)thunk->u1.Function;
+            if (saved && !*saved) *saved = (void *)thunk->u1.Function;
             DWORD old;
             if (!VirtualProtect(&thunk->u1.Function, sizeof(DWORD_PTR), PAGE_READWRITE, &old))
                 return FALSE;


### PR DESCRIPTION
## Summary
When running Radmin VPN on Linux via Wine, the service joined networks and connected to the Famatech control server, but **all peer connections failed** (`error: 0x700000000` / `0x7000003ed` in `service.log`), leaving peers reported as "offline" and the data plane stalled.

## Root Cause
1. **Mismatched RVAs in `src/adapter_hook.c`**:
   - `GETINETWORK_RVA` was hardcoded to `0x5BA70`, but in `RvControlSvc.exe` (2.1.4951.1) it resides at `0x67D00` (VA `0x00467D00`, prologue `56 57 8B`).
   - `DISPATCH_RVA` was `0x636A0` instead of `0x788C0` (VA `0x004788C0`, prologue `55 8B EC 6A FF`).
   - `FREE_RVA` was `0xC9001` instead of `0xE5807` (`sub_4E5807`), and `COUNTER_RVA` was `0x13F1D8` instead of `0x15C778` (`0x55C778`).
   - Due to the prologue check failing (`prologue mismatch, skip`), `GetINetwork` was never stubbed. As soon as the adapter became ready, `RvControlSvc.exe` cached a Wine `INetwork` COM object. During teardown, `sub_466900` called `IUnknown::Release()` on a dangling vtable pointer, crashing at `0x2C002B00` (`access-violation: exec @ 2C002B00`) and terminating the candidate gathering thread.
2. **`LD_PRELOAD` Path Splitting**:
   - `export LD_PRELOAD="$BUILD_DIR/rvpn_dnsfix.so..."` failed whenever the working directory contained spaces (e.g. `.../Área de trabalho/...`), preventing `rvpn_dnsfix.so` from loading.

## Changes
1. **`src/adapter_hook.c`**:
   - Updated `GETINETWORK_RVA` to `0x67D00` to properly stub `sub_467D00` with `xor al, al; ret` (bypassing the buggy Wine COM path).
   - Updated `DISPATCH_RVA` (`0x788C0`), `FREE_RVA` (`0xE5807`), and `COUNTER_RVA` (`0x15C778`) so the `hook_dispatch` task-guard is active.
   - Protected `*saved` in `hook_import` from being clobbered if already set.
2. **`run.sh`, `run_datacenter.sh`, `run_vps.sh`**:
   - Copied `rvpn_dnsfix.so` to `/tmp/rvpn_dnsfix.so` prior to setting `LD_PRELOAD`, fixing path whitespace parsing in `ld.so`.

## Testing
- Rebuilt with `make clean && make`.
- Verified in `radmin_hook_debug.log`:
  ```
  GetINetwork stubbed at RvControlSvc+0x67D00 (always return 0)
  task-guard installed at RvControlSvc+0x788C0
  ```
- Verified `radmin_service.log`: zero `ld.so` preload errors.
- Verified live service startup: reached `[+] Adapter ready — VPN IP: 26.220.186.51` with **zero crashes** (no `radmin_crash.log` generated).