### PR TITLE
feat(install): verify the pinned Radmin installer's sha256 before running it

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -69,10 +69,82 @@ boot_wineserver() {
 # Radmin's own in-app updater will otherwise push a newer build into a live
 # prefix mid-session, which kills the GUI and crashes the running service.
 # Shipping the current build is what keeps that updater with nothing to do.
-RADMIN_VERSION="${RADMIN_VERSION:-2.1.4951.1}"
+RADMIN_DEFAULT_VERSION="2.1.4951.1"
+RADMIN_VERSION="${RADMIN_VERSION:-$RADMIN_DEFAULT_VERSION}"
 radmin_installer_name() { printf 'Radmin_VPN_%s.exe' "$RADMIN_VERSION"; }
 radmin_installer_url() {
     printf 'https://download.radmin-vpn.com/download/files/Radmin_VPN_%s.exe' "$RADMIN_VERSION"
+}
+
+# ── Installer integrity ─────────────────────────────────────────────────────────
+# sha256 of Radmin_VPN_2.1.4951.1.exe (54277224 bytes) as published on
+# download.radmin-vpn.com. Confirmed to be the genuine vendor build: the file
+# carries an Authenticode signature whose embedded SHA-256 digest matches the
+# PE content, signed by "Famatech Corp." (C=VG) under DigiCert Trusted Root G4.
+#
+# Pinning the version without pinning the bytes leaves TLS as the only thing
+# standing between the prefix and a substituted installer, so this constant and
+# RADMIN_VERSION must be bumped as a pair.
+RADMIN_SHA256_PINNED="e16711e2e3e59f6603f51f437197215b1914a3d8316e1f633260178b959921f7"
+
+# Resolve which hash (if any) applies to the build we are about to run. Someone
+# testing a different release supplies RADMIN_SHA256 alongside RADMIN_VERSION;
+# without it there is nothing to check an unknown build against, and refusing to
+# run would break the documented RADMIN_VERSION override.
+if [ -n "${RADMIN_SHA256:-}" ]; then
+    :
+elif [ "$RADMIN_VERSION" = "$RADMIN_DEFAULT_VERSION" ]; then
+    RADMIN_SHA256="$RADMIN_SHA256_PINNED"
+else
+    RADMIN_SHA256=""
+fi
+
+# sha256 of $1 on stdout. Tries the three tools that realistically exist on a
+# host that can already build this project; returns non-zero when none do.
+_sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | cut -d' ' -f1
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | cut -d' ' -f1
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$1" | sed 's/.*= *//'
+    else
+        return 1
+    fi
+}
+
+# Check $1 before Wine executes it. Non-zero ONLY when the file claims to be the
+# pinned build and its hash disagrees — every other case warns and passes, so an
+# explicit --installer and a user-set RADMIN_VERSION keep working. The installer
+# runs unsandboxed under Wine with sudo already primed, so this is the last point
+# at which a substituted .exe can still be stopped cheaply.
+verify_installer() {
+    local f="$1" got name
+    [ -f "$f" ] || return 0
+    name="$(basename "$f")"
+
+    if [ -z "$RADMIN_SHA256" ]; then
+        warn "No pinned sha256 for Radmin $RADMIN_VERSION — installer NOT verified."
+        warn "  Set RADMIN_SHA256 to check it, or unset RADMIN_VERSION for the validated build."
+        return 0
+    fi
+    if [ "$name" != "$(radmin_installer_name)" ]; then
+        warn "$name is not the validated $RADMIN_VERSION build — installer NOT verified."
+        return 0
+    fi
+    if ! got="$(_sha256_of "$f")"; then
+        warn "No sha256sum/shasum/openssl on PATH — installer NOT verified."
+        return 0
+    fi
+    if [ "$got" != "$RADMIN_SHA256" ]; then
+        warn "Installer sha256 MISMATCH — refusing to run it."
+        warn "  file:     $f"
+        warn "  expected: $RADMIN_SHA256"
+        warn "  actual:   $got"
+        return 1
+    fi
+    good "Installer sha256 verified ($RADMIN_VERSION)"
+    return 0
 }
 
 # Version installed in $WINEPREFIX, read offline from the registry (no wine call).

--- a/lib.sh
+++ b/lib.sh
@@ -103,9 +103,9 @@ fi
 # host that can already build this project; returns non-zero when none do.
 _sha256_of() {
     if command -v sha256sum >/dev/null 2>&1; then
-        sha256sum "$1" | cut -d' ' -f1
+        sha256sum -- "$1" | cut -d' ' -f1
     elif command -v shasum >/dev/null 2>&1; then
-        shasum -a 256 "$1" | cut -d' ' -f1
+        shasum -a 256 -- "$1" | cut -d' ' -f1
     elif command -v openssl >/dev/null 2>&1; then
         openssl dgst -sha256 "$1" | sed 's/.*= *//'
     else
@@ -121,8 +121,7 @@ _sha256_of() {
 verify_installer() {
     local f="$1" got name
     [ -f "$f" ] || return 0
-    name="$(basename "$f")"
-
+    name="$(basename -- "$f")"
     if [ -z "$RADMIN_SHA256" ]; then
         warn "No pinned sha256 for Radmin $RADMIN_VERSION — installer NOT verified."
         warn "  Set RADMIN_SHA256 to check it, or unset RADMIN_VERSION for the validated build."

--- a/run.sh
+++ b/run.sh
@@ -227,7 +227,7 @@ install_radmin() {
         # a file the user pointed us at themselves.
         case "$INSTALLER" in
             "$DOWNLOAD_DIR"/*)
-                rm -f "$INSTALLER"
+                rm -f -- "$INSTALLER"
                 die "installer failed verification; cached copy removed — re-run to download it again" ;;
             *)
                 die "installer failed verification — refusing to run it" ;;

--- a/run.sh
+++ b/run.sh
@@ -220,6 +220,19 @@ install_radmin() {
     if [ -z "$INSTALLER" ] || [ ! -f "$INSTALLER" ]; then
         die "installer not found"
     fi
+    # Covers every path ensure_installer can take: fresh download, cached copy,
+    # --installer, and the any-version fallback.
+    if ! verify_installer "$INSTALLER"; then
+        # Drop our own poisoned cache so the next run refetches, but never delete
+        # a file the user pointed us at themselves.
+        case "$INSTALLER" in
+            "$DOWNLOAD_DIR"/*)
+                rm -f "$INSTALLER"
+                die "installer failed verification; cached copy removed — re-run to download it again" ;;
+            *)
+                die "installer failed verification — refusing to run it" ;;
+        esac
+    fi
     mkdir -p "$WINEPREFIX"
     wineboot --init 2>/dev/null
     if command -v winetricks >/dev/null 2>&1; then

--- a/run_datacenter.sh
+++ b/run_datacenter.sh
@@ -243,6 +243,7 @@ if [ ! -f "$RADMIN/RvControlSvc.exe" ]; then
         echo "    ./run_datacenter.sh --installer /path/to/Radmin_VPN_*.exe"
         exit 1
     fi
+    verify_installer "$INSTALLER" || die "installer failed verification — refusing to run it"
     say "Installing Radmin VPN..."
     mkdir -p "$WINEPREFIX"
     wineboot --init 2>/dev/null

--- a/run_vps.sh
+++ b/run_vps.sh
@@ -76,6 +76,7 @@ if [ ! -f "$RADMIN/RvControlSvc.exe" ]; then
         echo "    ./run_vps.sh --installer /path/to/Radmin_VPN_*.exe" >&2
         exit 1
     fi
+    verify_installer "$INSTALLER" || die "installer failed verification — refusing to run it"
     say "Installing Radmin VPN..."
     mkdir -p "$WINEPREFIX"
     wineboot --init 2>/dev/null


### PR DESCRIPTION
## What

`RADMIN_VERSION` pins which Radmin build the project is validated against, but nothing checked the bytes that actually arrive — TLS was the only thing standing between the prefix and a substituted installer. That `.exe` then runs unsandboxed under Wine with sudo already primed by `AppRun`, so a bad download is expensive.

This pins the sha256 next to the version and verifies it in all three launchers before `wine` executes the installer.

## Provenance of the pinned hash

`Radmin_VPN_2.1.4951.1.exe` as published on `download.radmin-vpn.com` (54,277,224 bytes):

```
e16711e2e3e59f6603f51f437197215b1914a3d8316e1f633260178b959921f7
```

Confirmed to be the genuine vendor build rather than just "whatever I happened to download": the file's Authenticode signature embeds a SHA-256 digest that matches the PE content recomputed over the Authenticode ranges (excluding the CheckSum field, the SECURITY data-directory entry and the certificate table), and the signing chain is

```
CN=Famatech Corp., O=Famatech Corp., L=Road Town, C=VG
  └─ CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1
       └─ CN=DigiCert Trusted Root G4
```

For full disclosure: I verified digest-to-content consistency and read the certificate chain, but did not validate the PKCS#7 RSA signature against a trust store (no `osslsigncode` on the test host).

## Behaviour

`verify_installer()` fails closed **only** when a file claims to be the pinned build and its hash disagrees. Every other case warns and continues, so no documented workflow breaks:

| Situation | Result |
| --- | --- |
| Pinned build, hash matches | `[+] Installer sha256 verified (2.1.4951.1)` |
| Pinned build, hash differs | **refuses to run** |
| `--installer` pointing at another release | warns, continues |
| `RADMIN_VERSION` overridden, no `RADMIN_SHA256` | warns, continues |
| `RADMIN_VERSION` + `RADMIN_SHA256` both set | enforced against the supplied hash |
| No `sha256sum` / `shasum` / `openssl` on PATH | warns, continues |

Bumping a Radmin release stays a two-line change: `RADMIN_VERSION` and `RADMIN_SHA256_PINNED` move together.

On mismatch `run.sh` removes its own cached download so the next run refetches it, but never deletes a file the user passed via `--installer`.

## Testing

`bash -n` clean on all four scripts. `verify_installer()` was exercised against the real 52 MB installer for every row of the table above, plus a tampered copy and a nonexistent path: matching hash passes, tampered copy returns 1, and each override behaves as tabulated.

Note that `run_vps.sh` / `run_datacenter.sh` never download — they only `find` a local `Radmin_VPN_*.exe` and hand it to `wine` — so they get the same check on that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
